### PR TITLE
Fix some bindings required for 3d animation

### DIFF
--- a/bindings.json
+++ b/bindings.json
@@ -15397,7 +15397,7 @@
         },
         {
           "name": "framePoses",
-          "typ": "?[*]Transform",
+          "typ": "?[*][*]Transform",
           "description": "Poses array by frame"
         },
         {
@@ -15407,7 +15407,7 @@
         }
       ],
       "description": "ModelAnimation",
-      "custom": false
+      "custom": true
     },
     {
       "name": "Ray",

--- a/generate.zig
+++ b/generate.zig
@@ -158,8 +158,8 @@ fn writeFunctions(
                 try file.writeAll(
                     try allocPrint(
                         allocator,
-                        ") [*]const {s} {{\n",
-                        .{stripType(func.returnType)},
+                        ") {s} {{\n",
+                        .{func.returnType},
                     ),
                 );
             }

--- a/raylib.zig
+++ b/raylib.zig
@@ -3947,7 +3947,7 @@ pub fn ImageColorReplace(
 /// Load color data from image as a Color array (RGBA - 32bit)
 pub fn LoadImageColors(
     image: Image,
-) [*]const Color {
+) ?[*]Color {
     return @as(
         ?[*]Color,
         @ptrCast(raylib.mLoadImageColors(
@@ -3961,7 +3961,7 @@ pub fn LoadImagePalette(
     image: Image,
     maxPaletteSize: i32,
     colorCount: ?[*]i32,
-) [*]const Color {
+) ?[*]Color {
     return @as(
         ?[*]Color,
         @ptrCast(raylib.mLoadImagePalette(
@@ -5036,7 +5036,7 @@ pub fn UnloadUTF8(
 pub fn LoadCodepoints(
     text: [*:0]const u8,
     count: ?[*]i32,
-) [*]const i32 {
+) ?[*]i32 {
     return @as(
         ?[*]i32,
         @ptrCast(raylib.mLoadCodepoints(
@@ -6092,7 +6092,7 @@ pub fn GenMeshCubicmap(
 pub fn LoadMaterials(
     fileName: [*:0]const u8,
     materialCount: ?[*]i32,
-) [*]const Material {
+) ?[*]Material {
     return @as(
         ?[*]Material,
         @ptrCast(raylib.mLoadMaterials(
@@ -6604,7 +6604,7 @@ pub fn WaveFormat(
 /// Load samples data from wave as a 32bit float data array
 pub fn LoadWaveSamples(
     wave: Wave,
-) [*]const f32 {
+) ?[*]f32 {
     return @as(
         ?[*]f32,
         @ptrCast(raylib.mLoadWaveSamples(
@@ -7639,7 +7639,7 @@ pub fn rlGetShaderIdDefault() u32 {
 }
 
 /// Get default shader locations
-pub fn rlGetShaderLocsDefault() [*]const i32 {
+pub fn rlGetShaderLocsDefault() ?[*]i32 {
     return @as(
         ?[*]i32,
         @ptrCast(raylib.mrlGetShaderLocsDefault()),
@@ -8001,7 +8001,7 @@ pub fn rlReadTexturePixels(
     width: i32,
     height: i32,
     format: i32,
-) [*]const anyopaque {
+) *anyopaque {
     return @as(
         *anyopaque,
         @ptrCast(raylib.mrlReadTexturePixels(

--- a/raylib.zig
+++ b/raylib.zig
@@ -6159,7 +6159,7 @@ pub fn SetModelMeshMaterial(
 pub fn LoadModelAnimations(
     fileName: [*:0]const u8,
     animCount: ?[*]u32,
-) [*]const ModelAnimation {
+) ?[*]ModelAnimation {
     return @as(
         ?[*]ModelAnimation,
         @ptrCast(raylib.mLoadModelAnimations(
@@ -10075,7 +10075,7 @@ pub const ModelAnimation = extern struct {
     /// Bones information (skeleton)
     bones: ?[*]BoneInfo,
     /// Poses array by frame
-    framePoses: ?[*]Transform,
+    framePoses: ?[*][*]Transform,
     /// Animation name
     name: [32]u8,
 };


### PR DESCRIPTION
Hello, I'm currently learning Zig so this PR might not be correct.

Changes required in order to implement 3d animation (https://github.com/ryupold/examples-raylib.zig/pull/7).
- Is there a reason why LoadModelAnimations returns [\*]const ModelAnimation but the cast is ?[\*]ModelAnimation in the function ? Seems like it causes error when LoadModelAnimations is called.
- I'm not sure I'm changing the bindings properly.

