### PR TITLE
Add support for Zig 1.13 & update Raylib to latest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ Mkfile.old
 dkms.conf
 
 zig-cache/
+.zig-cache
 
 .vscode/settings.json
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,23 @@ git submodule update --init --recursive
 
 The bindings have been prebuilt so you just need to add raylib as module
 
+build.zig.zon:
+```zig
+.{
+    .dependencies = .{
+        .raylib = .{
+            // Path to the raylib submodule inside of this repo
+            .path = "path/to/raylib/raylib",
+        },
+        // Only needed when using raygui
+        .raygui = .{
+            .path = "path/to/raygui",
+        },
+    },
+}
+
+```
+
 build.zig:
 ```zig
 const raylib = @import("path/to/raylib.zig/build.zig");

--- a/bindings.json
+++ b/bindings.json
@@ -887,10 +887,10 @@
       "custom": false
     },
     {
-      "name": "GetMouseRay",
+      "name": "GetScreenToWorldRay",
       "params": [
         {
-          "name": "mousePosition",
+          "name": "position",
           "typ": "Vector2"
         },
         {
@@ -899,31 +899,31 @@
         }
       ],
       "returnType": "Ray",
-      "description": "Get a ray trace from mouse position",
+      "description": "Get a ray trace from screen position (i.e mouse)",
       "custom": false
     },
     {
-      "name": "GetCameraMatrix",
+      "name": "GetScreenToWorldRayEx",
       "params": [
+        {
+          "name": "position",
+          "typ": "Vector2"
+        },
         {
           "name": "camera",
           "typ": "Camera3D"
-        }
-      ],
-      "returnType": "Matrix",
-      "description": "Get camera transform matrix (view matrix)",
-      "custom": false
-    },
-    {
-      "name": "GetCameraMatrix2D",
-      "params": [
+        },
         {
-          "name": "camera",
-          "typ": "Camera2D"
+          "name": "width",
+          "typ": "i32"
+        },
+        {
+          "name": "height",
+          "typ": "i32"
         }
       ],
-      "returnType": "Matrix",
-      "description": "Get camera 2d transform matrix",
+      "returnType": "Ray",
+      "description": "Get a ray trace from screen position (i.e mouse) in a viewport",
       "custom": false
     },
     {
@@ -940,22 +940,6 @@
       ],
       "returnType": "Vector2",
       "description": "Get the screen space position for a 3d world space position",
-      "custom": false
-    },
-    {
-      "name": "GetScreenToWorld2D",
-      "params": [
-        {
-          "name": "position",
-          "typ": "Vector2"
-        },
-        {
-          "name": "camera",
-          "typ": "Camera2D"
-        }
-      ],
-      "returnType": "Vector2",
-      "description": "Get the world space position for a 2d camera screen space position",
       "custom": false
     },
     {
@@ -996,6 +980,46 @@
       ],
       "returnType": "Vector2",
       "description": "Get the screen space position for a 2d camera world space position",
+      "custom": false
+    },
+    {
+      "name": "GetScreenToWorld2D",
+      "params": [
+        {
+          "name": "position",
+          "typ": "Vector2"
+        },
+        {
+          "name": "camera",
+          "typ": "Camera2D"
+        }
+      ],
+      "returnType": "Vector2",
+      "description": "Get the world space position for a 2d camera screen space position",
+      "custom": false
+    },
+    {
+      "name": "GetCameraMatrix",
+      "params": [
+        {
+          "name": "camera",
+          "typ": "Camera3D"
+        }
+      ],
+      "returnType": "Matrix",
+      "description": "Get camera transform matrix (view matrix)",
+      "custom": false
+    },
+    {
+      "name": "GetCameraMatrix2D",
+      "params": [
+        {
+          "name": "camera",
+          "typ": "Camera2D"
+        }
+      ],
+      "returnType": "Matrix",
+      "description": "Get camera 2d transform matrix",
       "custom": false
     },
     {
@@ -1540,6 +1564,18 @@
       "custom": false
     },
     {
+      "name": "IsFileNameValid",
+      "params": [
+        {
+          "name": "fileName",
+          "typ": "[*:0]const u8"
+        }
+      ],
+      "returnType": "bool",
+      "description": "Check if fileName is valid for the platform/OS",
+      "custom": false
+    },
+    {
       "name": "LoadDirectoryFiles",
       "params": [
         {
@@ -2009,6 +2045,26 @@
       "custom": false
     },
     {
+      "name": "SetGamepadVibration",
+      "params": [
+        {
+          "name": "gamepad",
+          "typ": "i32"
+        },
+        {
+          "name": "leftMotor",
+          "typ": "f32"
+        },
+        {
+          "name": "rightMotor",
+          "typ": "f32"
+        }
+      ],
+      "returnType": "void",
+      "description": "Set gamepad vibration for both motors",
+      "custom": false
+    },
+    {
       "name": "IsMouseButtonPressed",
       "params": [
         {
@@ -2452,7 +2508,7 @@
       "params": [
         {
           "name": "points",
-          "typ": "?[*]Vector2"
+          "typ": "?[*]const Vector2"
         },
         {
           "name": "pointCount",
@@ -3067,6 +3123,30 @@
           "typ": "i32"
         },
         {
+          "name": "color",
+          "typ": "Color"
+        }
+      ],
+      "returnType": "void",
+      "description": "Draw rectangle lines with rounded edges",
+      "custom": false
+    },
+    {
+      "name": "DrawRectangleRoundedLinesEx",
+      "params": [
+        {
+          "name": "rec",
+          "typ": "Rectangle"
+        },
+        {
+          "name": "roundness",
+          "typ": "f32"
+        },
+        {
+          "name": "segments",
+          "typ": "i32"
+        },
+        {
           "name": "lineThick",
           "typ": "f32"
         },
@@ -3132,7 +3212,7 @@
       "params": [
         {
           "name": "points",
-          "typ": "?[*]Vector2"
+          "typ": "?[*]const Vector2"
         },
         {
           "name": "pointCount",
@@ -3152,7 +3232,7 @@
       "params": [
         {
           "name": "points",
-          "typ": "?[*]Vector2"
+          "typ": "?[*]const Vector2"
         },
         {
           "name": "pointCount",
@@ -3260,7 +3340,7 @@
       "params": [
         {
           "name": "points",
-          "typ": "?[*]Vector2"
+          "typ": "?[*]const Vector2"
         },
         {
           "name": "pointCount",
@@ -3284,7 +3364,7 @@
       "params": [
         {
           "name": "points",
-          "typ": "?[*]Vector2"
+          "typ": "?[*]const Vector2"
         },
         {
           "name": "pointCount",
@@ -3308,7 +3388,7 @@
       "params": [
         {
           "name": "points",
-          "typ": "?[*]Vector2"
+          "typ": "?[*]const Vector2"
         },
         {
           "name": "pointCount",
@@ -3332,7 +3412,7 @@
       "params": [
         {
           "name": "points",
-          "typ": "?[*]Vector2"
+          "typ": "?[*]const Vector2"
         },
         {
           "name": "pointCount",
@@ -3356,7 +3436,7 @@
       "params": [
         {
           "name": "points",
-          "typ": "?[*]Vector2"
+          "typ": "?[*]const Vector2"
         },
         {
           "name": "pointCount",
@@ -3780,7 +3860,7 @@
         },
         {
           "name": "points",
-          "typ": "?[*]Vector2"
+          "typ": "?[*]const Vector2"
         },
         {
           "name": "pointCount",
@@ -3841,6 +3921,30 @@
       ],
       "returnType": "bool",
       "description": "Check if point belongs to line created between two points [p1] and [p2] with defined margin in pixels [threshold]",
+      "custom": false
+    },
+    {
+      "name": "CheckCollisionCircleLine",
+      "params": [
+        {
+          "name": "center",
+          "typ": "Vector2"
+        },
+        {
+          "name": "radius",
+          "typ": "f32"
+        },
+        {
+          "name": "p1",
+          "typ": "Vector2"
+        },
+        {
+          "name": "p2",
+          "typ": "Vector2"
+        }
+      ],
+      "returnType": "bool",
+      "description": "Check if circle collides with a line created betweeen two points [p1] and [p2]",
       "custom": false
     },
     {
@@ -5643,6 +5747,22 @@
       "custom": false
     },
     {
+      "name": "ColorIsEqual",
+      "params": [
+        {
+          "name": "col1",
+          "typ": "Color"
+        },
+        {
+          "name": "col2",
+          "typ": "Color"
+        }
+      ],
+      "returnType": "bool",
+      "description": "Check if two colors are equal",
+      "custom": false
+    },
+    {
       "name": "Fade",
       "params": [
         {
@@ -5667,7 +5787,7 @@
         }
       ],
       "returnType": "i32",
-      "description": "Get hexadecimal value for a Color",
+      "description": "Get hexadecimal value for a Color (0xRRGGBBAA)",
       "custom": false
     },
     {
@@ -6738,6 +6858,30 @@
       "custom": false
     },
     {
+      "name": "TextToSnake",
+      "params": [
+        {
+          "name": "text",
+          "typ": "[*:0]const u8"
+        }
+      ],
+      "returnType": "[*:0]const u8",
+      "description": "Get Snake case notation version of provided string",
+      "custom": false
+    },
+    {
+      "name": "TextToCamel",
+      "params": [
+        {
+          "name": "text",
+          "typ": "[*:0]const u8"
+        }
+      ],
+      "returnType": "[*:0]const u8",
+      "description": "Get Camel case notation version of provided string",
+      "custom": false
+    },
+    {
       "name": "TextToInteger",
       "params": [
         {
@@ -6854,7 +6998,7 @@
       "params": [
         {
           "name": "points",
-          "typ": "?[*]Vector3"
+          "typ": "?[*]const Vector3"
         },
         {
           "name": "pointCount",
@@ -8636,16 +8780,16 @@
           "typ": "?[*]Wave"
         },
         {
-          "name": "initSample",
+          "name": "initFrame",
           "typ": "i32"
         },
         {
-          "name": "finalSample",
+          "name": "finalFrame",
           "typ": "i32"
         }
       ],
       "returnType": "void",
-      "description": "Crop a wave to defined samples range",
+      "description": "Crop a wave to defined frames range",
       "custom": false
     },
     {
@@ -9137,7 +9281,7 @@
         }
       ],
       "returnType": "void",
-      "description": "Attach audio stream processor to stream, receives the samples as <float>s",
+      "description": "Attach audio stream processor to stream, receives the samples as 'float'",
       "custom": false
     },
     {
@@ -9165,7 +9309,7 @@
         }
       ],
       "returnType": "void",
-      "description": "Attach audio stream processor to the entire audio pipeline, receives the samples as <float>s",
+      "description": "Attach audio stream processor to the entire audio pipeline, receives the samples as 'float'",
       "custom": false
     },
     {
@@ -9375,6 +9519,36 @@
       ],
       "returnType": "void",
       "description": "Set the viewport area",
+      "custom": false
+    },
+    {
+      "name": "rlSetClipPlanes",
+      "params": [
+        {
+          "name": "nearPlane",
+          "typ": "f64"
+        },
+        {
+          "name": "farPlane",
+          "typ": "f64"
+        }
+      ],
+      "returnType": "void",
+      "description": "Set clip planes distances",
+      "custom": false
+    },
+    {
+      "name": "rlGetCullDistanceNear",
+      "params": [],
+      "returnType": "f64",
+      "description": "Get cull plane distance near",
+      "custom": false
+    },
+    {
+      "name": "rlGetCullDistanceFar",
+      "params": [],
+      "returnType": "f64",
+      "description": "Get cull plane distance far",
       "custom": false
     },
     {
@@ -9790,6 +9964,13 @@
       "custom": false
     },
     {
+      "name": "rlGetActiveFramebuffer",
+      "params": [],
+      "returnType": "u32",
+      "description": "Get the currently active render texture (fbo), 0 for default framebuffer",
+      "custom": false
+    },
+    {
       "name": "rlActiveDrawBuffers",
       "params": [
         {
@@ -9858,7 +10039,7 @@
         }
       ],
       "returnType": "void",
-      "description": "Bind framebuffer (FBO) ",
+      "description": "Bind framebuffer (FBO)",
       "custom": false
     },
     {
@@ -10829,16 +11010,7 @@
     },
     {
       "name": "rlLoadFramebuffer",
-      "params": [
-        {
-          "name": "width",
-          "typ": "i32"
-        },
-        {
-          "name": "height",
-          "typ": "i32"
-        }
-      ],
+      "params": [],
       "returnType": "u32",
       "description": "Load an empty framebuffer",
       "custom": false
@@ -11285,7 +11457,7 @@
         }
       ],
       "returnType": "Matrix",
-      "description": "",
+      "description": "Get internal projection matrix for stereo render (selected eye)",
       "custom": false
     },
     {
@@ -11297,7 +11469,7 @@
         }
       ],
       "returnType": "Matrix",
-      "description": "",
+      "description": "Get internal view offset matrix for stereo render (selected eye)",
       "custom": false
     },
     {
@@ -11801,6 +11973,38 @@
       "custom": false
     },
     {
+      "name": "Vector2Min",
+      "params": [
+        {
+          "name": "v1",
+          "typ": "Vector2"
+        },
+        {
+          "name": "v2",
+          "typ": "Vector2"
+        }
+      ],
+      "returnType": "Vector2",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "Vector2Max",
+      "params": [
+        {
+          "name": "v1",
+          "typ": "Vector2"
+        },
+        {
+          "name": "v2",
+          "typ": "Vector2"
+        }
+      ],
+      "returnType": "Vector2",
+      "description": "",
+      "custom": false
+    },
+    {
       "name": "Vector2Rotate",
       "params": [
         {
@@ -11901,6 +12105,26 @@
         }
       ],
       "returnType": "i32",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "Vector2Refract",
+      "params": [
+        {
+          "name": "v",
+          "typ": "Vector2"
+        },
+        {
+          "name": "n",
+          "typ": "Vector2"
+        },
+        {
+          "name": "r",
+          "typ": "f32"
+        }
+      ],
+      "returnType": "Vector2",
       "description": "",
       "custom": false
     },
@@ -12271,6 +12495,26 @@
       "custom": false
     },
     {
+      "name": "Vector3MoveTowards",
+      "params": [
+        {
+          "name": "v",
+          "typ": "Vector3"
+        },
+        {
+          "name": "target",
+          "typ": "Vector3"
+        },
+        {
+          "name": "maxDistance",
+          "typ": "f32"
+        }
+      ],
+      "returnType": "Vector3",
+      "description": "",
+      "custom": false
+    },
+    {
       "name": "Vector3Lerp",
       "params": [
         {
@@ -12279,6 +12523,34 @@
         },
         {
           "name": "v2",
+          "typ": "Vector3"
+        },
+        {
+          "name": "amount",
+          "typ": "f32"
+        }
+      ],
+      "returnType": "Vector3",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "Vector3CubicHermite",
+      "params": [
+        {
+          "name": "v1",
+          "typ": "Vector3"
+        },
+        {
+          "name": "tangent1",
+          "typ": "Vector3"
+        },
+        {
+          "name": "v2",
+          "typ": "Vector3"
+        },
+        {
+          "name": "tangent2",
           "typ": "Vector3"
         },
         {
@@ -12479,6 +12751,328 @@
         }
       ],
       "returnType": "Vector3",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "Vector4Zero",
+      "params": [],
+      "returnType": "Vector4",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "Vector4One",
+      "params": [],
+      "returnType": "Vector4",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "Vector4Add",
+      "params": [
+        {
+          "name": "v1",
+          "typ": "Vector4"
+        },
+        {
+          "name": "v2",
+          "typ": "Vector4"
+        }
+      ],
+      "returnType": "Vector4",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "Vector4AddValue",
+      "params": [
+        {
+          "name": "v",
+          "typ": "Vector4"
+        },
+        {
+          "name": "add",
+          "typ": "f32"
+        }
+      ],
+      "returnType": "Vector4",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "Vector4Subtract",
+      "params": [
+        {
+          "name": "v1",
+          "typ": "Vector4"
+        },
+        {
+          "name": "v2",
+          "typ": "Vector4"
+        }
+      ],
+      "returnType": "Vector4",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "Vector4SubtractValue",
+      "params": [
+        {
+          "name": "v",
+          "typ": "Vector4"
+        },
+        {
+          "name": "add",
+          "typ": "f32"
+        }
+      ],
+      "returnType": "Vector4",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "Vector4Length",
+      "params": [
+        {
+          "name": "v",
+          "typ": "Vector4"
+        }
+      ],
+      "returnType": "f32",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "Vector4LengthSqr",
+      "params": [
+        {
+          "name": "v",
+          "typ": "Vector4"
+        }
+      ],
+      "returnType": "f32",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "Vector4DotProduct",
+      "params": [
+        {
+          "name": "v1",
+          "typ": "Vector4"
+        },
+        {
+          "name": "v2",
+          "typ": "Vector4"
+        }
+      ],
+      "returnType": "f32",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "Vector4Distance",
+      "params": [
+        {
+          "name": "v1",
+          "typ": "Vector4"
+        },
+        {
+          "name": "v2",
+          "typ": "Vector4"
+        }
+      ],
+      "returnType": "f32",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "Vector4DistanceSqr",
+      "params": [
+        {
+          "name": "v1",
+          "typ": "Vector4"
+        },
+        {
+          "name": "v2",
+          "typ": "Vector4"
+        }
+      ],
+      "returnType": "f32",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "Vector4Scale",
+      "params": [
+        {
+          "name": "v",
+          "typ": "Vector4"
+        },
+        {
+          "name": "scale",
+          "typ": "f32"
+        }
+      ],
+      "returnType": "Vector4",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "Vector4Multiply",
+      "params": [
+        {
+          "name": "v1",
+          "typ": "Vector4"
+        },
+        {
+          "name": "v2",
+          "typ": "Vector4"
+        }
+      ],
+      "returnType": "Vector4",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "Vector4Negate",
+      "params": [
+        {
+          "name": "v",
+          "typ": "Vector4"
+        }
+      ],
+      "returnType": "Vector4",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "Vector4Divide",
+      "params": [
+        {
+          "name": "v1",
+          "typ": "Vector4"
+        },
+        {
+          "name": "v2",
+          "typ": "Vector4"
+        }
+      ],
+      "returnType": "Vector4",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "Vector4Normalize",
+      "params": [
+        {
+          "name": "v",
+          "typ": "Vector4"
+        }
+      ],
+      "returnType": "Vector4",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "Vector4Min",
+      "params": [
+        {
+          "name": "v1",
+          "typ": "Vector4"
+        },
+        {
+          "name": "v2",
+          "typ": "Vector4"
+        }
+      ],
+      "returnType": "Vector4",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "Vector4Max",
+      "params": [
+        {
+          "name": "v1",
+          "typ": "Vector4"
+        },
+        {
+          "name": "v2",
+          "typ": "Vector4"
+        }
+      ],
+      "returnType": "Vector4",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "Vector4Lerp",
+      "params": [
+        {
+          "name": "v1",
+          "typ": "Vector4"
+        },
+        {
+          "name": "v2",
+          "typ": "Vector4"
+        },
+        {
+          "name": "amount",
+          "typ": "f32"
+        }
+      ],
+      "returnType": "Vector4",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "Vector4MoveTowards",
+      "params": [
+        {
+          "name": "v",
+          "typ": "Vector4"
+        },
+        {
+          "name": "target",
+          "typ": "Vector4"
+        },
+        {
+          "name": "maxDistance",
+          "typ": "f32"
+        }
+      ],
+      "returnType": "Vector4",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "Vector4Invert",
+      "params": [
+        {
+          "name": "v",
+          "typ": "Vector4"
+        }
+      ],
+      "returnType": "Vector4",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "Vector4Equals",
+      "params": [
+        {
+          "name": "p",
+          "typ": "Vector4"
+        },
+        {
+          "name": "q",
+          "typ": "Vector4"
+        }
+      ],
+      "returnType": "i32",
       "description": "",
       "custom": false
     },
@@ -12721,11 +13315,11 @@
           "typ": "f64"
         },
         {
-          "name": "near",
+          "name": "nearPlane",
           "typ": "f64"
         },
         {
-          "name": "far",
+          "name": "farPlane",
           "typ": "f64"
         }
       ],
@@ -13029,6 +13623,34 @@
         },
         {
           "name": "amount",
+          "typ": "f32"
+        }
+      ],
+      "returnType": "Vector4",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "QuaternionCubicHermiteSpline",
+      "params": [
+        {
+          "name": "q1",
+          "typ": "Vector4"
+        },
+        {
+          "name": "outTangent1",
+          "typ": "Vector4"
+        },
+        {
+          "name": "q2",
+          "typ": "Vector4"
+        },
+        {
+          "name": "inTangent2",
+          "typ": "Vector4"
+        },
+        {
+          "name": "t",
           "typ": "f32"
         }
       ],
@@ -14024,7 +14646,7 @@
         {
           "name": "GAMEPAD_BUTTON_RIGHT_FACE_RIGHT",
           "value": 6,
-          "description": "Gamepad right button right (i.e. PS3: Square, Xbox: X)"
+          "description": "Gamepad right button right (i.e. PS3: Circle, Xbox: B)"
         },
         {
           "name": "GAMEPAD_BUTTON_RIGHT_FACE_DOWN",
@@ -14034,7 +14656,7 @@
         {
           "name": "GAMEPAD_BUTTON_RIGHT_FACE_LEFT",
           "value": 8,
-          "description": "Gamepad right button left (i.e. PS3: Circle, Xbox: B)"
+          "description": "Gamepad right button left (i.e. PS3: Square, Xbox: X)"
         },
         {
           "name": "GAMEPAD_BUTTON_LEFT_TRIGGER_1",
@@ -14049,7 +14671,7 @@
         {
           "name": "GAMEPAD_BUTTON_RIGHT_TRIGGER_1",
           "value": 11,
-          "description": "Gamepad top/back trigger right (one), it could be a trailing button"
+          "description": "Gamepad top/back trigger right (first), it could be a trailing button"
         },
         {
           "name": "GAMEPAD_BUTTON_RIGHT_TRIGGER_2",
@@ -14765,27 +15387,27 @@
         {
           "name": "CAMERA_CUSTOM",
           "value": 0,
-          "description": "Custom camera"
+          "description": "Camera custom, controlled by user (UpdateCamera() does nothing)"
         },
         {
           "name": "CAMERA_FREE",
           "value": 1,
-          "description": "Free camera"
+          "description": "Camera free mode"
         },
         {
           "name": "CAMERA_ORBITAL",
           "value": 2,
-          "description": "Orbital camera"
+          "description": "Camera orbital, around target, zoom supported"
         },
         {
           "name": "CAMERA_FIRST_PERSON",
           "value": 3,
-          "description": "First person camera"
+          "description": "Camera first person"
         },
         {
           "name": "CAMERA_THIRD_PERSON",
           "value": 4,
-          "description": "Third person camera"
+          "description": "Camera third person"
         }
       ],
       "description": "Camera system modes",
@@ -16813,6 +17435,18 @@
       "custom": true
     },
     {
+      "name": "rl_float16",
+      "fields": [
+        {
+          "name": "v",
+          "typ": "[16]f32",
+          "description": ""
+        }
+      ],
+      "description": "Auxiliar matrix math functions",
+      "custom": false
+    },
+    {
       "name": "float3",
       "fields": [
         {
@@ -16869,7 +17503,7 @@
     {
       "name": "PI",
       "typ": "f32",
-      "value": "3.14159265358979323846",
+      "value": "3.141592653589793e0",
       "description": "",
       "custom": false
     },
@@ -17058,7 +17692,7 @@
     {
       "name": "RLGL_VERSION",
       "typ": "[]const u8",
-      "value": "\"4.5\"",
+      "value": "\"5.0\"",
       "description": "",
       "custom": false
     },
@@ -17107,14 +17741,14 @@
     {
       "name": "RL_CULL_DISTANCE_NEAR",
       "typ": "f64",
-      "value": "0.01",
+      "value": "1e-2",
       "description": "Default near cull distance",
       "custom": false
     },
     {
       "name": "RL_CULL_DISTANCE_FAR",
       "typ": "f64",
-      "value": "1000.0",
+      "value": "1e3",
       "description": "Default far cull distance",
       "custom": false
     },
@@ -17581,6 +18215,48 @@
       "custom": false
     },
     {
+      "name": "RL_DEFAULT_SHADER_ATTRIB_LOCATION_POSITION",
+      "typ": "i32",
+      "value": "0",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "RL_DEFAULT_SHADER_ATTRIB_LOCATION_TEXCOORD",
+      "typ": "i32",
+      "value": "1",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "RL_DEFAULT_SHADER_ATTRIB_LOCATION_NORMAL",
+      "typ": "i32",
+      "value": "2",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "RL_DEFAULT_SHADER_ATTRIB_LOCATION_COLOR",
+      "typ": "i32",
+      "value": "3",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "RL_DEFAULT_SHADER_ATTRIB_LOCATION_TANGENT",
+      "typ": "i32",
+      "value": "4",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "RL_DEFAULT_SHADER_ATTRIB_LOCATION_TEXCOORD2",
+      "typ": "i32",
+      "value": "5",
+      "description": "",
+      "custom": false
+    },
+    {
       "name": "GL_SHADING_LANGUAGE_VERSION",
       "typ": "i32",
       "value": "35724",
@@ -17679,6 +18355,20 @@
       "custom": false
     },
     {
+      "name": "GL_PROGRAM_POINT_SIZE",
+      "typ": "i32",
+      "value": "34370",
+      "description": "",
+      "custom": false
+    },
+    {
+      "name": "GL_LINE_WIDTH",
+      "typ": "i32",
+      "value": "2849",
+      "description": "",
+      "custom": false
+    },
+    {
       "name": "GL_UNSIGNED_SHORT_5_6_5",
       "typ": "i32",
       "value": "33635",
@@ -17717,42 +18407,42 @@
       "name": "RL_DEFAULT_SHADER_ATTRIB_NAME_POSITION",
       "typ": "[]const u8",
       "value": "\"vertexPosition\"",
-      "description": "Bound by default to shader location: 0",
+      "description": "Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_NAME_POSITION",
       "custom": false
     },
     {
       "name": "RL_DEFAULT_SHADER_ATTRIB_NAME_TEXCOORD",
       "typ": "[]const u8",
       "value": "\"vertexTexCoord\"",
-      "description": "Bound by default to shader location: 1",
+      "description": "Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_NAME_TEXCOORD",
       "custom": false
     },
     {
       "name": "RL_DEFAULT_SHADER_ATTRIB_NAME_NORMAL",
       "typ": "[]const u8",
       "value": "\"vertexNormal\"",
-      "description": "Bound by default to shader location: 2",
+      "description": "Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_NAME_NORMAL",
       "custom": false
     },
     {
       "name": "RL_DEFAULT_SHADER_ATTRIB_NAME_COLOR",
       "typ": "[]const u8",
       "value": "\"vertexColor\"",
-      "description": "Bound by default to shader location: 3",
+      "description": "Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_NAME_COLOR",
       "custom": false
     },
     {
       "name": "RL_DEFAULT_SHADER_ATTRIB_NAME_TANGENT",
       "typ": "[]const u8",
       "value": "\"vertexTangent\"",
-      "description": "Bound by default to shader location: 4",
+      "description": "Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_NAME_TANGENT",
       "custom": false
     },
     {
       "name": "RL_DEFAULT_SHADER_ATTRIB_NAME_TEXCOORD2",
       "typ": "[]const u8",
       "value": "\"vertexTexCoord2\"",
-      "description": "Bound by default to shader location: 5",
+      "description": "Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_NAME_TEXCOORD2",
       "custom": false
     },
     {
@@ -17821,7 +18511,7 @@
     {
       "name": "EPSILON",
       "typ": "f32",
-      "value": "0.000001",
+      "value": "1e-6",
       "description": "",
       "custom": false
     }

--- a/build.zig
+++ b/build.zig
@@ -10,11 +10,14 @@ pub fn build(b: *std.Build) !void {
     const jsons = b.step("parse", "parse raylib headers and generate raylib jsons");
     const raylib_parser_build = b.addExecutable(.{
         .name = "raylib_parser",
-        .root_source_file = std.build.FileSource.relative("raylib_parser.zig"),
+        .root_source_file = b.path("raylib_parser.zig"),
         .target = target,
         .optimize = .ReleaseFast,
     });
-    raylib_parser_build.addCSourceFile(.{ .file = .{ .path = "raylib/parser/raylib_parser.c" }, .flags = &.{} });
+    raylib_parser_build.addCSourceFile(.{
+        .file = b.path("raylib/parser/raylib_parser.c"),
+        .flags = &.{},
+    });
     raylib_parser_build.linkLibC();
 
     //raylib
@@ -51,7 +54,7 @@ pub fn build(b: *std.Build) !void {
     const intermediate = b.step("intermediate", "generate intermediate representation of the results from 'zig build parse' (keep custom=true)");
     var intermediateZigStep = b.addRunArtifact(b.addExecutable(.{
         .name = "intermediate",
-        .root_source_file = std.build.FileSource.relative("intermediate.zig"),
+        .root_source_file = b.path("intermediate.zig"),
         .target = target,
     }));
     intermediate.dependOn(&intermediateZigStep.step);
@@ -60,7 +63,7 @@ pub fn build(b: *std.Build) !void {
     const bindings = b.step("bindings", "generate bindings in from bindings.json");
     var generateZigStep = b.addRunArtifact(b.addExecutable(.{
         .name = "generate",
-        .root_source_file = std.build.FileSource.relative("generate.zig"),
+        .root_source_file = b.path("generate.zig"),
         .target = target,
     }));
     const fmt = b.addFmt(.{ .paths = &.{generate.outputFile} });
@@ -84,30 +87,42 @@ const sep = std.fs.path.sep_str;
 const cwd = std.fs.path.dirname(current_file()).?;
 const dir_raylib = cwd ++ sep ++ "raylib" ++ sep ++ "src";
 
-const raylib_build = @import("raylib/src/build.zig");
+const raylib_build = @import("raylib");
 
 fn linkThisLibrary(b: *std.Build, target: std.Target.Query, optimize: std.builtin.Mode) *std.Build.Step.Compile {
-    const lib = b.addStaticLibrary(.{ .name = "raylib.zig", .target = b.resolveTargetQuery(target), .optimize = optimize });
-    lib.addIncludePath(.{ .path = dir_raylib });
-    lib.addIncludePath(.{ .path = cwd });
+    const lib = b.addStaticLibrary(
+        .{
+            .name = "raylib.zig",
+            .target = b.resolveTargetQuery(target),
+            .optimize = optimize,
+            .root_source_file = std.Build.LazyPath{
+                .cwd_relative = cwd ++ sep ++ "raylib.zig",
+            },
+        },
+    );
     lib.linkLibC();
-    lib.addCSourceFile(.{ .file = .{ .path = cwd ++ sep ++ "marshal.c" }, .flags = &.{} });
-    std.log.info("include '{s}' to {s}", .{ dir_raylib, lib.name });
-    std.log.info("include '{s}' to {s}", .{ cwd, lib.name });
+    lib.addIncludePath(std.Build.LazyPath{ .cwd_relative = dir_raylib });
+    lib.addIncludePath(std.Build.LazyPath{ .cwd_relative = cwd });
+    lib.addCSourceFile(.{ .file = std.Build.LazyPath{ .cwd_relative = cwd ++ sep ++ "marshal.c" }, .flags = &.{} });
+    std.log.debug("include '{s}' to {s}", .{ dir_raylib, lib.name });
+    std.log.debug("include '{s}' to {s}", .{ cwd, lib.name });
     return lib;
 }
 
 /// add this package to exe
-pub fn addTo(b: *std.Build, exe: *std.Build.Step.Compile, target: std.Target.Query, optimize: std.builtin.Mode, raylibOptions: raylib_build.Options) void {
-    exe.root_module.addAnonymousImport("raylib", .{ .root_source_file = .{ .path = cwd ++ sep ++ "raylib.zig" } });
-    std.log.info("include '{s}' to {s}", .{ dir_raylib, exe.name });
-    std.log.info("include '{s}' to {s}", .{ cwd, exe.name });
-    exe.addIncludePath(.{ .path = dir_raylib });
-    exe.addIncludePath(.{ .path = cwd });
+pub fn addTo(b: *std.Build, exe: *std.Build.Step.Compile, target: std.Target.Query, optimize: std.builtin.Mode, raylibOptions: anytype) void {
+    const lib_raylib = raylib_build.addRaylib(
+        b,
+        b.resolveTargetQuery(target),
+        optimize,
+        raylibOptions,
+    ) catch |err| std.debug.panic("addRaylib: {any}", .{err});
+
     const lib = linkThisLibrary(b, target, optimize);
-    const lib_raylib = raylib_build.addRaylib(b, b.resolveTargetQuery(target), optimize, raylibOptions) catch |err| std.debug.panic("addRaylib: {any}", .{err});
+
+    exe.root_module.addImport("raylib", &lib.root_module);
+
     exe.linkLibrary(lib_raylib);
-    exe.linkLibrary(lib);
     std.log.info("linked raylib.zig", .{});
 }
 

--- a/generate.zig
+++ b/generate.zig
@@ -176,7 +176,7 @@ fn writeFunctions(
 
         //--- body ------------------------------
         if (isPointer(func.returnType)) {
-            try file.writeAll(try allocPrint(allocator, "return @ptrCast({s},\n", .{func.returnType}));
+            try file.writeAll(try allocPrint(allocator, "return @as({s},@ptrCast(\n", .{func.returnType}));
         } else if (isPrimitiveOrPointer(func.returnType)) {
             try file.writeAll("return ");
         } else if (!returnTypeIsVoid) {
@@ -186,9 +186,9 @@ fn writeFunctions(
 
         if (!isPrimitiveOrPointer(func.returnType)) {
             if (bindings.containsStruct(stripType(func.returnType))) {
-                try file.writeAll(try allocPrint(allocator, "@ptrCast([*c]raylib.{s}, &out),\n", .{func.returnType}));
+                try file.writeAll(try allocPrint(allocator, "@as([*c]raylib.{s}, @ptrCast(&out)),\n", .{func.returnType}));
             } else if (!returnTypeIsVoid) {
-                try file.writeAll(try allocPrint(allocator, "@ptrCast([*c]{s}, &out),\n", .{func.returnType}));
+                try file.writeAll(try allocPrint(allocator, "@as([*c]{s}, @ptrCast(&out)),\n", .{func.returnType}));
             }
         }
 
@@ -196,18 +196,18 @@ fn writeFunctions(
             if (isFunctionPointer(param.typ)) {
                 try file.writeAll(try allocPrint(allocator, "@ptrCast({s}),\n", .{param.name}));
             } else if (bindings.containsStruct(stripType(param.typ)) and isPointer(param.typ)) {
-                try file.writeAll(try allocPrint(allocator, "@intToPtr([*c]raylib.{s}, @ptrToInt({s})),\n", .{ stripType(param.typ), param.name }));
+                try file.writeAll(try allocPrint(allocator, "@as([*c]raylib.{s}, @ptrFromInt(@intFromPtr({s}))),\n", .{ stripType(param.typ), param.name }));
             } else if (bindings.containsEnum(param.typ)) {
-                try file.writeAll(try allocPrint(allocator, "@enumToInt({s}),\n", .{param.name}));
+                try file.writeAll(try allocPrint(allocator, "@intFromEnum({s}),\n", .{param.name}));
             } else if (bindings.containsStruct(stripType(param.typ))) {
-                try file.writeAll(try allocPrint(allocator, "@intToPtr([*c]raylib.{s}, @ptrToInt(&{s})),\n", .{ stripType(param.typ), param.name }));
+                try file.writeAll(try allocPrint(allocator, "@as([*c]raylib.{s}, @ptrFromInt(@intFromPtr(&{s}))),\n", .{ stripType(param.typ), param.name }));
             } else if (isPointer(param.typ)) {
                 if (std.mem.endsWith(u8, param.typ, "anyopaque")) {
                     try file.writeAll(try allocPrint(allocator, "{s},\n", .{param.name}));
                 } else if (isConst(param.typ)) {
-                    try file.writeAll(try allocPrint(allocator, "@intToPtr([*c]const {s}, @ptrToInt({s})),\n", .{ stripType(param.typ), param.name }));
+                    try file.writeAll(try allocPrint(allocator, "@as([*c]const {s}, @ptrFromInt(@intFromPtr({s}))),\n", .{ stripType(param.typ), param.name }));
                 } else {
-                    try file.writeAll(try allocPrint(allocator, "@ptrCast([*c]{s}, {s}),\n", .{ stripType(param.typ), param.name }));
+                    try file.writeAll(try allocPrint(allocator, "@as([*c]{s}, @ptrCast({s})),\n", .{ stripType(param.typ), param.name }));
                 }
             } else {
                 try file.writeAll(try allocPrint(allocator, "{s},\n", .{param.name}));
@@ -215,7 +215,7 @@ fn writeFunctions(
         }
 
         if (isPointer(func.returnType)) {
-            try file.writeAll("),\n);\n");
+            try file.writeAll("),\n));\n");
         } else {
             try file.writeAll(");\n");
         }
@@ -511,7 +511,7 @@ fn stripType(z: []const u8) []const u8 {
 /// true if Zig type is primitive or a pointer to anything
 /// this means we don't need to wrap it in a pointer
 pub fn isPrimitiveOrPointer(z: []const u8) bool {
-    const primitiveTypes = std.ComptimeStringMap(void, .{
+    const primitiveTypes = std.StaticStringMap(void).initComptime(.{
         // .{ "void", {} }, // zig void is zero sized while C void is >= 1 byte
         .{ "bool", {} },
         .{ "u8", {} },

--- a/marshal.c
+++ b/marshal.c
@@ -413,29 +413,19 @@ void mUnloadShader(Shader *shader)
 	UnloadShader(*shader);
 }
 
-void mGetMouseRay(Ray *out, Vector2 *mousePosition, Camera3D *camera)
+void mGetScreenToWorldRay(Ray *out, Vector2 *position, Camera3D *camera)
 {
-	*out = GetMouseRay(*mousePosition, *camera);
+	*out = GetScreenToWorldRay(*position, *camera);
 }
 
-void mGetCameraMatrix(Matrix *out, Camera3D *camera)
+void mGetScreenToWorldRayEx(Ray *out, Vector2 *position, Camera3D *camera, int width, int height)
 {
-	*out = GetCameraMatrix(*camera);
-}
-
-void mGetCameraMatrix2D(Matrix *out, Camera2D *camera)
-{
-	*out = GetCameraMatrix2D(*camera);
+	*out = GetScreenToWorldRayEx(*position, *camera, width, height);
 }
 
 void mGetWorldToScreen(Vector2 *out, Vector3 *position, Camera3D *camera)
 {
 	*out = GetWorldToScreen(*position, *camera);
-}
-
-void mGetScreenToWorld2D(Vector2 *out, Vector2 *position, Camera2D *camera)
-{
-	*out = GetScreenToWorld2D(*position, *camera);
 }
 
 void mGetWorldToScreenEx(Vector2 *out, Vector3 *position, Camera3D *camera, int width, int height)
@@ -446,6 +436,21 @@ void mGetWorldToScreenEx(Vector2 *out, Vector3 *position, Camera3D *camera, int 
 void mGetWorldToScreen2D(Vector2 *out, Vector2 *position, Camera2D *camera)
 {
 	*out = GetWorldToScreen2D(*position, *camera);
+}
+
+void mGetScreenToWorld2D(Vector2 *out, Vector2 *position, Camera2D *camera)
+{
+	*out = GetScreenToWorld2D(*position, *camera);
+}
+
+void mGetCameraMatrix(Matrix *out, Camera3D *camera)
+{
+	*out = GetCameraMatrix(*camera);
+}
+
+void mGetCameraMatrix2D(Matrix *out, Camera2D *camera)
+{
+	*out = GetCameraMatrix2D(*camera);
 }
 
 void mSetTargetFPS(int fps)
@@ -628,6 +633,11 @@ bool mIsPathFile(const char * path)
 	return IsPathFile(path);
 }
 
+bool mIsFileNameValid(const char * fileName)
+{
+	return IsFileNameValid(fileName);
+}
+
 void mLoadDirectoryFiles(FilePathList *out, const char * dirPath)
 {
 	*out = LoadDirectoryFiles(dirPath);
@@ -806,6 +816,11 @@ float mGetGamepadAxisMovement(int gamepad, int axis)
 int mSetGamepadMappings(const char * mappings)
 {
 	return SetGamepadMappings(mappings);
+}
+
+void mSetGamepadVibration(int gamepad, float leftMotor, float rightMotor)
+{
+	SetGamepadVibration(gamepad, leftMotor, rightMotor);
 }
 
 bool mIsMouseButtonPressed(int button)
@@ -993,7 +1008,7 @@ void mDrawLineEx(Vector2 *startPos, Vector2 *endPos, float thick, Color *color)
 	DrawLineEx(*startPos, *endPos, thick, *color);
 }
 
-void mDrawLineStrip(Vector2 * points, int pointCount, Color *color)
+void mDrawLineStrip(const Vector2 * points, int pointCount, Color *color)
 {
 	DrawLineStrip(points, pointCount, *color);
 }
@@ -1108,9 +1123,14 @@ void mDrawRectangleRounded(Rectangle *rec, float roundness, int segments, Color 
 	DrawRectangleRounded(*rec, roundness, segments, *color);
 }
 
-void mDrawRectangleRoundedLines(Rectangle *rec, float roundness, int segments, float lineThick, Color *color)
+void mDrawRectangleRoundedLines(Rectangle *rec, float roundness, int segments, Color *color)
 {
-	DrawRectangleRoundedLines(*rec, roundness, segments, lineThick, *color);
+	DrawRectangleRoundedLines(*rec, roundness, segments, *color);
+}
+
+void mDrawRectangleRoundedLinesEx(Rectangle *rec, float roundness, int segments, float lineThick, Color *color)
+{
+	DrawRectangleRoundedLinesEx(*rec, roundness, segments, lineThick, *color);
 }
 
 void mDrawTriangle(Vector2 *v1, Vector2 *v2, Vector2 *v3, Color *color)
@@ -1123,12 +1143,12 @@ void mDrawTriangleLines(Vector2 *v1, Vector2 *v2, Vector2 *v3, Color *color)
 	DrawTriangleLines(*v1, *v2, *v3, *color);
 }
 
-void mDrawTriangleFan(Vector2 * points, int pointCount, Color *color)
+void mDrawTriangleFan(const Vector2 * points, int pointCount, Color *color)
 {
 	DrawTriangleFan(points, pointCount, *color);
 }
 
-void mDrawTriangleStrip(Vector2 * points, int pointCount, Color *color)
+void mDrawTriangleStrip(const Vector2 * points, int pointCount, Color *color)
 {
 	DrawTriangleStrip(points, pointCount, *color);
 }
@@ -1148,27 +1168,27 @@ void mDrawPolyLinesEx(Vector2 *center, int sides, float radius, float rotation, 
 	DrawPolyLinesEx(*center, sides, radius, rotation, lineThick, *color);
 }
 
-void mDrawSplineLinear(Vector2 * points, int pointCount, float thick, Color *color)
+void mDrawSplineLinear(const Vector2 * points, int pointCount, float thick, Color *color)
 {
 	DrawSplineLinear(points, pointCount, thick, *color);
 }
 
-void mDrawSplineBasis(Vector2 * points, int pointCount, float thick, Color *color)
+void mDrawSplineBasis(const Vector2 * points, int pointCount, float thick, Color *color)
 {
 	DrawSplineBasis(points, pointCount, thick, *color);
 }
 
-void mDrawSplineCatmullRom(Vector2 * points, int pointCount, float thick, Color *color)
+void mDrawSplineCatmullRom(const Vector2 * points, int pointCount, float thick, Color *color)
 {
 	DrawSplineCatmullRom(points, pointCount, thick, *color);
 }
 
-void mDrawSplineBezierQuadratic(Vector2 * points, int pointCount, float thick, Color *color)
+void mDrawSplineBezierQuadratic(const Vector2 * points, int pointCount, float thick, Color *color)
 {
 	DrawSplineBezierQuadratic(points, pointCount, thick, *color);
 }
 
-void mDrawSplineBezierCubic(Vector2 * points, int pointCount, float thick, Color *color)
+void mDrawSplineBezierCubic(const Vector2 * points, int pointCount, float thick, Color *color)
 {
 	DrawSplineBezierCubic(points, pointCount, thick, *color);
 }
@@ -1253,7 +1273,7 @@ bool mCheckCollisionPointTriangle(Vector2 *point, Vector2 *p1, Vector2 *p2, Vect
 	return CheckCollisionPointTriangle(*point, *p1, *p2, *p3);
 }
 
-bool mCheckCollisionPointPoly(Vector2 *point, Vector2 * points, int pointCount)
+bool mCheckCollisionPointPoly(Vector2 *point, const Vector2 * points, int pointCount)
 {
 	return CheckCollisionPointPoly(*point, points, pointCount);
 }
@@ -1266,6 +1286,11 @@ bool mCheckCollisionLines(Vector2 *startPos1, Vector2 *endPos1, Vector2 *startPo
 bool mCheckCollisionPointLine(Vector2 *point, Vector2 *p1, Vector2 *p2, int threshold)
 {
 	return CheckCollisionPointLine(*point, *p1, *p2, threshold);
+}
+
+bool mCheckCollisionCircleLine(Vector2 *center, float radius, Vector2 *p1, Vector2 *p2)
+{
+	return CheckCollisionCircleLine(*center, radius, *p1, *p2);
 }
 
 void mGetCollisionRec(Rectangle *out, Rectangle *rec1, Rectangle *rec2)
@@ -1733,6 +1758,11 @@ void mDrawTextureNPatch(Texture2D *texture, NPatchInfo *nPatchInfo, Rectangle *d
 	DrawTextureNPatch(*texture, *nPatchInfo, *dest, *origin, rotation, *tint);
 }
 
+bool mColorIsEqual(Color *col1, Color *col2)
+{
+	return ColorIsEqual(*col1, *col2);
+}
+
 void mFade(Color *out, Color *color, float alpha)
 {
 	*out = Fade(*color, alpha);
@@ -2013,6 +2043,16 @@ const char * mTextToPascal(const char * text)
 	return TextToPascal(text);
 }
 
+const char * mTextToSnake(const char * text)
+{
+	return TextToSnake(text);
+}
+
+const char * mTextToCamel(const char * text)
+{
+	return TextToCamel(text);
+}
+
 int mTextToInteger(const char * text)
 {
 	return TextToInteger(text);
@@ -2043,7 +2083,7 @@ void mDrawTriangle3D(Vector3 *v1, Vector3 *v2, Vector3 *v3, Color *color)
 	DrawTriangle3D(*v1, *v2, *v3, *color);
 }
 
-void mDrawTriangleStrip3D(Vector3 * points, int pointCount, Color *color)
+void mDrawTriangleStrip3D(const Vector3 * points, int pointCount, Color *color)
 {
 	DrawTriangleStrip3D(points, pointCount, *color);
 }
@@ -2523,9 +2563,9 @@ void mWaveCopy(Wave *out, Wave *wave)
 	*out = WaveCopy(*wave);
 }
 
-void mWaveCrop(Wave * wave, int initSample, int finalSample)
+void mWaveCrop(Wave * wave, int initFrame, int finalFrame)
 {
-	WaveCrop(wave, initSample, finalSample);
+	WaveCrop(wave, initFrame, finalFrame);
 }
 
 void mWaveFormat(Wave * wave, int sampleRate, int sampleSize, int channels)
@@ -2773,6 +2813,21 @@ void mrlViewport(int x, int y, int width, int height)
 	rlViewport(x, y, width, height);
 }
 
+void mrlSetClipPlanes(double nearPlane, double farPlane)
+{
+	rlSetClipPlanes(nearPlane, farPlane);
+}
+
+double mrlGetCullDistanceNear(void)
+{
+	return rlGetCullDistanceNear();
+}
+
+double mrlGetCullDistanceFar(void)
+{
+	return rlGetCullDistanceFar();
+}
+
 void mrlBegin(int mode)
 {
 	rlBegin(mode);
@@ -2916,6 +2971,11 @@ void mrlEnableFramebuffer(unsigned int id)
 void mrlDisableFramebuffer(void)
 {
 	rlDisableFramebuffer();
+}
+
+unsigned int mrlGetActiveFramebuffer(void)
+{
+	return rlGetActiveFramebuffer();
 }
 
 void mrlActiveDrawBuffers(int count)
@@ -3203,9 +3263,9 @@ void mrlUnloadVertexBuffer(unsigned int vboId)
 	rlUnloadVertexBuffer(vboId);
 }
 
-void mrlSetVertexAttribute(unsigned int index, int compSize, int type, bool normalized, int stride, const void * pointer)
+void mrlSetVertexAttribute(unsigned int index, int compSize, int type, bool normalized, int stride, int offset)
 {
-	rlSetVertexAttribute(index, compSize, type, normalized, stride, pointer);
+	rlSetVertexAttribute(index, compSize, type, normalized, stride, offset);
 }
 
 void mrlSetVertexAttributeDivisor(unsigned int index, int divisor)
@@ -3288,9 +3348,9 @@ unsigned char * mrlReadScreenPixels(int width, int height)
 	return rlReadScreenPixels(width, height);
 }
 
-unsigned int mrlLoadFramebuffer(int width, int height)
+unsigned int mrlLoadFramebuffer(void)
 {
-	return rlLoadFramebuffer(width, height);
+	return rlLoadFramebuffer();
 }
 
 void mrlFramebufferAttach(unsigned int fboId, unsigned int texId, int attachType, int texType, int mipLevel)
@@ -3598,6 +3658,16 @@ void mVector2Reflect(Vector2 *out, Vector2 *v, Vector2 *normal)
 	*out = Vector2Reflect(*v, *normal);
 }
 
+void mVector2Min(Vector2 *out, Vector2 *v1, Vector2 *v2)
+{
+	*out = Vector2Min(*v1, *v2);
+}
+
+void mVector2Max(Vector2 *out, Vector2 *v1, Vector2 *v2)
+{
+	*out = Vector2Max(*v1, *v2);
+}
+
 void mVector2Rotate(Vector2 *out, Vector2 *v, float angle)
 {
 	*out = Vector2Rotate(*v, angle);
@@ -3626,6 +3696,11 @@ void mVector2ClampValue(Vector2 *out, Vector2 *v, float min, float max)
 int mVector2Equals(Vector2 *p, Vector2 *q)
 {
 	return Vector2Equals(*p, *q);
+}
+
+void mVector2Refract(Vector2 *out, Vector2 *v, Vector2 *n, float r)
+{
+	*out = Vector2Refract(*v, *n, r);
 }
 
 void mVector3Zero(Vector3 *out)
@@ -3753,9 +3828,19 @@ void mVector3RotateByAxisAngle(Vector3 *out, Vector3 *v, Vector3 *axis, float an
 	*out = Vector3RotateByAxisAngle(*v, *axis, angle);
 }
 
+void mVector3MoveTowards(Vector3 *out, Vector3 *v, Vector3 *target, float maxDistance)
+{
+	*out = Vector3MoveTowards(*v, *target, maxDistance);
+}
+
 void mVector3Lerp(Vector3 *out, Vector3 *v1, Vector3 *v2, float amount)
 {
 	*out = Vector3Lerp(*v1, *v2, amount);
+}
+
+void mVector3CubicHermite(Vector3 *out, Vector3 *v1, Vector3 *tangent1, Vector3 *v2, Vector3 *tangent2, float amount)
+{
+	*out = Vector3CubicHermite(*v1, *tangent1, *v2, *tangent2, amount);
 }
 
 void mVector3Reflect(Vector3 *out, Vector3 *v, Vector3 *normal)
@@ -3811,6 +3896,116 @@ int mVector3Equals(Vector3 *p, Vector3 *q)
 void mVector3Refract(Vector3 *out, Vector3 *v, Vector3 *n, float r)
 {
 	*out = Vector3Refract(*v, *n, r);
+}
+
+void mVector4Zero(Vector4 *out)
+{
+	*out = Vector4Zero();
+}
+
+void mVector4One(Vector4 *out)
+{
+	*out = Vector4One();
+}
+
+void mVector4Add(Vector4 *out, Vector4 *v1, Vector4 *v2)
+{
+	*out = Vector4Add(*v1, *v2);
+}
+
+void mVector4AddValue(Vector4 *out, Vector4 *v, float add)
+{
+	*out = Vector4AddValue(*v, add);
+}
+
+void mVector4Subtract(Vector4 *out, Vector4 *v1, Vector4 *v2)
+{
+	*out = Vector4Subtract(*v1, *v2);
+}
+
+void mVector4SubtractValue(Vector4 *out, Vector4 *v, float add)
+{
+	*out = Vector4SubtractValue(*v, add);
+}
+
+float mVector4Length(Vector4 *v)
+{
+	return Vector4Length(*v);
+}
+
+float mVector4LengthSqr(Vector4 *v)
+{
+	return Vector4LengthSqr(*v);
+}
+
+float mVector4DotProduct(Vector4 *v1, Vector4 *v2)
+{
+	return Vector4DotProduct(*v1, *v2);
+}
+
+float mVector4Distance(Vector4 *v1, Vector4 *v2)
+{
+	return Vector4Distance(*v1, *v2);
+}
+
+float mVector4DistanceSqr(Vector4 *v1, Vector4 *v2)
+{
+	return Vector4DistanceSqr(*v1, *v2);
+}
+
+void mVector4Scale(Vector4 *out, Vector4 *v, float scale)
+{
+	*out = Vector4Scale(*v, scale);
+}
+
+void mVector4Multiply(Vector4 *out, Vector4 *v1, Vector4 *v2)
+{
+	*out = Vector4Multiply(*v1, *v2);
+}
+
+void mVector4Negate(Vector4 *out, Vector4 *v)
+{
+	*out = Vector4Negate(*v);
+}
+
+void mVector4Divide(Vector4 *out, Vector4 *v1, Vector4 *v2)
+{
+	*out = Vector4Divide(*v1, *v2);
+}
+
+void mVector4Normalize(Vector4 *out, Vector4 *v)
+{
+	*out = Vector4Normalize(*v);
+}
+
+void mVector4Min(Vector4 *out, Vector4 *v1, Vector4 *v2)
+{
+	*out = Vector4Min(*v1, *v2);
+}
+
+void mVector4Max(Vector4 *out, Vector4 *v1, Vector4 *v2)
+{
+	*out = Vector4Max(*v1, *v2);
+}
+
+void mVector4Lerp(Vector4 *out, Vector4 *v1, Vector4 *v2, float amount)
+{
+	*out = Vector4Lerp(*v1, *v2, amount);
+}
+
+void mVector4MoveTowards(Vector4 *out, Vector4 *v, Vector4 *target, float maxDistance)
+{
+	*out = Vector4MoveTowards(*v, *target, maxDistance);
+}
+
+void mVector4Invert(Vector4 *out, Vector4 *v)
+{
+	*out = Vector4Invert(*v);
+}
+
+int mVector4Equals(Vector4 *p, Vector4 *q)
+{
+	return Vector4Equals(*p, *q);
 }
 
 float mMatrixDeterminant(Matrix *mat)
@@ -3893,9 +4088,9 @@ void mMatrixScale(Matrix *out, float x, float y, float z)
 	*out = MatrixScale(x, y, z);
 }
 
-void mMatrixFrustum(Matrix *out, double left, double right, double bottom, double top, double near, double far)
+void mMatrixFrustum(Matrix *out, double left, double right, double bottom, double top, double nearPlane, double farPlane)
 {
-	*out = MatrixFrustum(left, right, bottom, top, near, far);
+	*out = MatrixFrustum(left, right, bottom, top, nearPlane, farPlane);
 }
 
 void mMatrixPerspective(Matrix *out, double fovY, double aspect, double nearPlane, double farPlane)
@@ -3986,6 +4181,11 @@ void mQuaternionNlerp(Vector4 *out, Vector4 *q1, Vector4 *q2, float amount)
 void mQuaternionSlerp(Vector4 *out, Vector4 *q1, Vector4 *q2, float amount)
 {
 	*out = QuaternionSlerp(*q1, *q2, amount);
+}
+
+void mQuaternionCubicHermiteSpline(Vector4 *out, Vector4 *q1, Vector4 *outTangent1, Vector4 *q2, Vector4 *inTangent2, float t)
+{
+	*out = QuaternionCubicHermiteSpline(*q1, *outTangent1, *q2, *inTangent2, t);
 }
 
 void mQuaternionFromVector3ToVector3(Vector4 *out, Vector3 *from, Vector3 *to)

--- a/marshal.h
+++ b/marshal.h
@@ -255,26 +255,29 @@ void mSetShaderValueTexture(Shader *shader, int locIndex, Texture2D *texture);
 // Unload shader from GPU memory (VRAM)
 void mUnloadShader(Shader *shader);
 
-// Get a ray trace from mouse position
-void mGetMouseRay(Ray *out, Vector2 *mousePosition, Camera3D *camera);
+// Get a ray trace from screen position (i.e mouse)
+void mGetScreenToWorldRay(Ray *out, Vector2 *position, Camera3D *camera);
 
-// Get camera transform matrix (view matrix)
-void mGetCameraMatrix(Matrix *out, Camera3D *camera);
-
-// Get camera 2d transform matrix
-void mGetCameraMatrix2D(Matrix *out, Camera2D *camera);
+// Get a ray trace from screen position (i.e mouse) in a viewport
+void mGetScreenToWorldRayEx(Ray *out, Vector2 *position, Camera3D *camera, int width, int height);
 
 // Get the screen space position for a 3d world space position
 void mGetWorldToScreen(Vector2 *out, Vector3 *position, Camera3D *camera);
-
-// Get the world space position for a 2d camera screen space position
-void mGetScreenToWorld2D(Vector2 *out, Vector2 *position, Camera2D *camera);
 
 // Get size position for a 3d world space position
 void mGetWorldToScreenEx(Vector2 *out, Vector3 *position, Camera3D *camera, int width, int height);
 
 // Get the screen space position for a 2d camera world space position
 void mGetWorldToScreen2D(Vector2 *out, Vector2 *position, Camera2D *camera);
+
+// Get the world space position for a 2d camera screen space position
+void mGetScreenToWorld2D(Vector2 *out, Vector2 *position, Camera2D *camera);
+
+// Get camera transform matrix (view matrix)
+void mGetCameraMatrix(Matrix *out, Camera3D *camera);
+
+// Get camera 2d transform matrix
+void mGetCameraMatrix2D(Matrix *out, Camera2D *camera);
 
 // Set target FPS (maximum)
 void mSetTargetFPS(int fps);
@@ -384,6 +387,9 @@ bool mChangeDirectory(const char * dir);
 // Check if a given path is a file or a directory
 bool mIsPathFile(const char * path);
 
+// Check if fileName is valid for the platform/OS
+bool mIsFileNameValid(const char * fileName);
+
 // Load directory filepaths
 void mLoadDirectoryFiles(FilePathList *out, const char * dirPath);
 
@@ -491,6 +497,9 @@ float mGetGamepadAxisMovement(int gamepad, int axis);
 
 // Set internal gamepad mappings (SDL_GameControllerDB)
 int mSetGamepadMappings(const char * mappings);
+
+// Set gamepad vibration for both motors
+void mSetGamepadVibration(int gamepad, float leftMotor, float rightMotor);
 
 // Check if a mouse button has been pressed once
 bool mIsMouseButtonPressed(int button);
@@ -604,7 +613,7 @@ void mDrawLineV(Vector2 *startPos, Vector2 *endPos, Color *color);
 void mDrawLineEx(Vector2 *startPos, Vector2 *endPos, float thick, Color *color);
 
 // Draw lines sequence (using gl lines)
-void mDrawLineStrip(Vector2 * points, int pointCount, Color *color);
+void mDrawLineStrip(const Vector2 * points, int pointCount, Color *color);
 
 // Draw line segment cubic-bezier in-out interpolation
 void mDrawLineBezier(Vector2 *startPos, Vector2 *endPos, float thick, Color *color);
@@ -672,8 +681,11 @@ void mDrawRectangleLinesEx(Rectangle *rec, float lineThick, Color *color);
 // Draw rectangle with rounded edges
 void mDrawRectangleRounded(Rectangle *rec, float roundness, int segments, Color *color);
 
+// Draw rectangle lines with rounded edges
+void mDrawRectangleRoundedLines(Rectangle *rec, float roundness, int segments, Color *color);
+
 // Draw rectangle with rounded edges outline
-void mDrawRectangleRoundedLines(Rectangle *rec, float roundness, int segments, float lineThick, Color *color);
+void mDrawRectangleRoundedLinesEx(Rectangle *rec, float roundness, int segments, float lineThick, Color *color);
 
 // Draw a color-filled triangle (vertex in counter-clockwise order!)
 void mDrawTriangle(Vector2 *v1, Vector2 *v2, Vector2 *v3, Color *color);
@@ -682,10 +694,10 @@ void mDrawTriangle(Vector2 *v1, Vector2 *v2, Vector2 *v3, Color *color);
 void mDrawTriangleLines(Vector2 *v1, Vector2 *v2, Vector2 *v3, Color *color);
 
 // Draw a triangle fan defined by points (first vertex is the center)
-void mDrawTriangleFan(Vector2 * points, int pointCount, Color *color);
+void mDrawTriangleFan(const Vector2 * points, int pointCount, Color *color);
 
 // Draw a triangle strip defined by points
-void mDrawTriangleStrip(Vector2 * points, int pointCount, Color *color);
+void mDrawTriangleStrip(const Vector2 * points, int pointCount, Color *color);
 
 // Draw a regular polygon (Vector version)
 void mDrawPoly(Vector2 *center, int sides, float radius, float rotation, Color *color);
@@ -697,19 +709,19 @@ void mDrawPolyLines(Vector2 *center, int sides, float radius, float rotation, Co
 void mDrawPolyLinesEx(Vector2 *center, int sides, float radius, float rotation, float lineThick, Color *color);
 
 // Draw spline: Linear, minimum 2 points
-void mDrawSplineLinear(Vector2 * points, int pointCount, float thick, Color *color);
+void mDrawSplineLinear(const Vector2 * points, int pointCount, float thick, Color *color);
 
 // Draw spline: B-Spline, minimum 4 points
-void mDrawSplineBasis(Vector2 * points, int pointCount, float thick, Color *color);
+void mDrawSplineBasis(const Vector2 * points, int pointCount, float thick, Color *color);
 
 // Draw spline: Catmull-Rom, minimum 4 points
-void mDrawSplineCatmullRom(Vector2 * points, int pointCount, float thick, Color *color);
+void mDrawSplineCatmullRom(const Vector2 * points, int pointCount, float thick, Color *color);
 
 // Draw spline: Quadratic Bezier, minimum 3 points (1 control point): [p1, c2, p3, c4...]
-void mDrawSplineBezierQuadratic(Vector2 * points, int pointCount, float thick, Color *color);
+void mDrawSplineBezierQuadratic(const Vector2 * points, int pointCount, float thick, Color *color);
 
 // Draw spline: Cubic Bezier, minimum 4 points (2 control points): [p1, c2, c3, p4, c5, c6...]
-void mDrawSplineBezierCubic(Vector2 * points, int pointCount, float thick, Color *color);
+void mDrawSplineBezierCubic(const Vector2 * points, int pointCount, float thick, Color *color);
 
 // Draw spline segment: Linear, 2 points
 void mDrawSplineSegmentLinear(Vector2 *p1, Vector2 *p2, float thick, Color *color);
@@ -760,13 +772,16 @@ bool mCheckCollisionPointCircle(Vector2 *point, Vector2 *center, float radius);
 bool mCheckCollisionPointTriangle(Vector2 *point, Vector2 *p1, Vector2 *p2, Vector2 *p3);
 
 // Check if point is within a polygon described by array of vertices
-bool mCheckCollisionPointPoly(Vector2 *point, Vector2 * points, int pointCount);
+bool mCheckCollisionPointPoly(Vector2 *point, const Vector2 * points, int pointCount);
 
 // Check the collision between two lines defined by two points each, returns collision point by reference
 bool mCheckCollisionLines(Vector2 *startPos1, Vector2 *endPos1, Vector2 *startPos2, Vector2 *endPos2, Vector2 * collisionPoint);
 
 // Check if point belongs to line created between two points [p1] and [p2] with defined margin in pixels [threshold]
 bool mCheckCollisionPointLine(Vector2 *point, Vector2 *p1, Vector2 *p2, int threshold);
+
+// Check if circle collides with a line created betweeen two points [p1] and [p2]
+bool mCheckCollisionCircleLine(Vector2 *center, float radius, Vector2 *p1, Vector2 *p2);
 
 // Get collision rectangle for two rectangles collision
 void mGetCollisionRec(Rectangle *out, Rectangle *rec1, Rectangle *rec2);
@@ -1047,10 +1062,13 @@ void mDrawTexturePro(Texture2D *texture, Rectangle *source, Rectangle *dest, Vec
 // Draws a texture (or part of it) that stretches or shrinks nicely
 void mDrawTextureNPatch(Texture2D *texture, NPatchInfo *nPatchInfo, Rectangle *dest, Vector2 *origin, float rotation, Color *tint);
 
+// Check if two colors are equal
+bool mColorIsEqual(Color *col1, Color *col2);
+
 // Get color with alpha applied, alpha goes from 0.0f to 1.0f
 void mFade(Color *out, Color *color, float alpha);
 
-// Get hexadecimal value for a Color
+// Get hexadecimal value for a Color (0xRRGGBBAA)
 int mColorToInt(Color *color);
 
 // Get Color normalized as float [0..1]
@@ -1215,6 +1233,12 @@ const char * mTextToLower(const char * text);
 // Get Pascal case notation version of provided string
 const char * mTextToPascal(const char * text);
 
+// Get Snake case notation version of provided string
+const char * mTextToSnake(const char * text);
+
+// Get Camel case notation version of provided string
+const char * mTextToCamel(const char * text);
+
 // Get integer value from text (negative values not supported)
 int mTextToInteger(const char * text);
 
@@ -1234,7 +1258,7 @@ void mDrawCircle3D(Vector3 *center, float radius, Vector3 *rotationAxis, float r
 void mDrawTriangle3D(Vector3 *v1, Vector3 *v2, Vector3 *v3, Color *color);
 
 // Draw a triangle strip defined by points
-void mDrawTriangleStrip3D(Vector3 * points, int pointCount, Color *color);
+void mDrawTriangleStrip3D(const Vector3 * points, int pointCount, Color *color);
 
 // Draw cube
 void mDrawCube(Vector3 *position, float width, float height, float length, Color *color);
@@ -1521,8 +1545,8 @@ void mSetSoundPan(Sound *sound, float pan);
 // Copy a wave to a new wave
 void mWaveCopy(Wave *out, Wave *wave);
 
-// Crop a wave to defined samples range
-void mWaveCrop(Wave * wave, int initSample, int finalSample);
+// Crop a wave to defined frames range
+void mWaveCrop(Wave * wave, int initFrame, int finalFrame);
 
 // Convert wave data to desired format
 void mWaveFormat(Wave * wave, int sampleRate, int sampleSize, int channels);
@@ -1626,13 +1650,13 @@ void mSetAudioStreamBufferSizeDefault(int size);
 // Audio thread callback to request new data
 void mSetAudioStreamCallback(AudioStream *stream, AudioCallback callback);
 
-// Attach audio stream processor to stream, receives the samples as <float>s
+// Attach audio stream processor to stream, receives the samples as 'float'
 void mAttachAudioStreamProcessor(AudioStream *stream, AudioCallback processor);
 
 // Detach audio stream processor from stream
 void mDetachAudioStreamProcessor(AudioStream *stream, AudioCallback processor);
 
-// Attach audio stream processor to the entire audio pipeline, receives the samples as <float>s
+// Attach audio stream processor to the entire audio pipeline, receives the samples as 'float'
 void mAttachAudioMixedProcessor(AudioCallback processor);
 
 // Detach audio stream processor from the entire audio pipeline
@@ -1670,6 +1694,15 @@ void mrlOrtho(double left, double right, double bottom, double top, double znear
 
 // Set the viewport area
 void mrlViewport(int x, int y, int width, int height);
+
+// Set clip planes distances
+void mrlSetClipPlanes(double nearPlane, double farPlane);
+
+// Get cull plane distance near
+double mrlGetCullDistanceNear(void);
+
+// Get cull plane distance far
+double mrlGetCullDistanceFar(void);
 
 // Initialize drawing mode (how to organize vertex)
 void mrlBegin(int mode);
@@ -1758,13 +1791,16 @@ void mrlEnableFramebuffer(unsigned int id);
 // Disable render texture (fbo), return to default framebuffer
 void mrlDisableFramebuffer(void);
 
+// Get the currently active render texture (fbo), 0 for default framebuffer
+unsigned int mrlGetActiveFramebuffer(void);
+
 // Activate multiple draw color buffers
 void mrlActiveDrawBuffers(int count);
 
 // Blit active framebuffer to main framebuffer
 void mrlBlitFramebuffer(int srcX, int srcY, int srcWidth, int srcHeight, int dstX, int dstY, int dstWidth, int dstHeight, int bufferMask);
 
-// Bind framebuffer (FBO) 
+// Bind framebuffer (FBO)
 void mrlBindFramebuffer(unsigned int target, unsigned int framebuffer);
 
 // Enable color blending
@@ -1930,7 +1966,7 @@ void mrlUnloadVertexArray(unsigned int vaoId);
 void mrlUnloadVertexBuffer(unsigned int vboId);
 
 // Set vertex attribute data configuration
-void mrlSetVertexAttribute(unsigned int index, int compSize, int type, bool normalized, int stride, const void * pointer);
+void mrlSetVertexAttribute(unsigned int index, int compSize, int type, bool normalized, int stride, int offset);
 
 // Set vertex attribute data divisor
 void mrlSetVertexAttributeDivisor(unsigned int index, int divisor);
@@ -1981,7 +2017,7 @@ void * mrlReadTexturePixels(unsigned int id, int width, int height, int format);
 unsigned char * mrlReadScreenPixels(int width, int height);
 
 // Load an empty framebuffer
-unsigned int mrlLoadFramebuffer(int width, int height);
+unsigned int mrlLoadFramebuffer(void);
 
 // Attach texture/renderbuffer to a framebuffer
 void mrlFramebufferAttach(unsigned int fboId, unsigned int texId, int attachType, int texType, int mipLevel);
@@ -2061,10 +2097,10 @@ void mrlGetMatrixProjection(Matrix *out);
 // Get internal accumulated transform matrix
 void mrlGetMatrixTransform(Matrix *out);
 
-// 
+// Get internal projection matrix for stereo render (selected eye)
 void mrlGetMatrixProjectionStereo(Matrix *out, int eye);
 
-// 
+// Get internal view offset matrix for stereo render (selected eye)
 void mrlGetMatrixViewOffsetStereo(Matrix *out, int eye);
 
 // Set a custom projection matrix (replaces internal projection matrix)
@@ -2167,6 +2203,12 @@ void mVector2Lerp(Vector2 *out, Vector2 *v1, Vector2 *v2, float amount);
 void mVector2Reflect(Vector2 *out, Vector2 *v, Vector2 *normal);
 
 // 
+void mVector2Min(Vector2 *out, Vector2 *v1, Vector2 *v2);
+
+// 
+void mVector2Max(Vector2 *out, Vector2 *v1, Vector2 *v2);
+
+// 
 void mVector2Rotate(Vector2 *out, Vector2 *v, float angle);
 
 // 
@@ -2183,6 +2225,9 @@ void mVector2ClampValue(Vector2 *out, Vector2 *v, float min, float max);
 
 // 
 int mVector2Equals(Vector2 *p, Vector2 *q);
+
+// 
+void mVector2Refract(Vector2 *out, Vector2 *v, Vector2 *n, float r);
 
 // 
 void mVector3Zero(Vector3 *out);
@@ -2260,7 +2305,13 @@ void mVector3RotateByQuaternion(Vector3 *out, Vector3 *v, Vector4 *q);
 void mVector3RotateByAxisAngle(Vector3 *out, Vector3 *v, Vector3 *axis, float angle);
 
 // 
+void mVector3MoveTowards(Vector3 *out, Vector3 *v, Vector3 *target, float maxDistance);
+
+// 
 void mVector3Lerp(Vector3 *out, Vector3 *v1, Vector3 *v2, float amount);
+
+// 
+void mVector3CubicHermite(Vector3 *out, Vector3 *v1, Vector3 *tangent1, Vector3 *v2, Vector3 *tangent2, float amount);
 
 // 
 void mVector3Reflect(Vector3 *out, Vector3 *v, Vector3 *normal);
@@ -2294,6 +2345,72 @@ int mVector3Equals(Vector3 *p, Vector3 *q);
 
 // 
 void mVector3Refract(Vector3 *out, Vector3 *v, Vector3 *n, float r);
+
+// 
+void mVector4Zero(Vector4 *out);
+
+// 
+void mVector4One(Vector4 *out);
+
+// 
+void mVector4Add(Vector4 *out, Vector4 *v1, Vector4 *v2);
+
+// 
+void mVector4AddValue(Vector4 *out, Vector4 *v, float add);
+
+// 
+void mVector4Subtract(Vector4 *out, Vector4 *v1, Vector4 *v2);
+
+// 
+void mVector4SubtractValue(Vector4 *out, Vector4 *v, float add);
+
+// 
+float mVector4Length(Vector4 *v);
+
+// 
+float mVector4LengthSqr(Vector4 *v);
+
+// 
+float mVector4DotProduct(Vector4 *v1, Vector4 *v2);
+
+// 
+float mVector4Distance(Vector4 *v1, Vector4 *v2);
+
+// 
+float mVector4DistanceSqr(Vector4 *v1, Vector4 *v2);
+
+// 
+void mVector4Scale(Vector4 *out, Vector4 *v, float scale);
+
+// 
+void mVector4Multiply(Vector4 *out, Vector4 *v1, Vector4 *v2);
+
+// 
+void mVector4Negate(Vector4 *out, Vector4 *v);
+
+// 
+void mVector4Divide(Vector4 *out, Vector4 *v1, Vector4 *v2);
+
+// 
+void mVector4Normalize(Vector4 *out, Vector4 *v);
+
+// 
+void mVector4Min(Vector4 *out, Vector4 *v1, Vector4 *v2);
+
+// 
+void mVector4Max(Vector4 *out, Vector4 *v1, Vector4 *v2);
+
+// 
+void mVector4Lerp(Vector4 *out, Vector4 *v1, Vector4 *v2, float amount);
+
+// 
+void mVector4MoveTowards(Vector4 *out, Vector4 *v, Vector4 *target, float maxDistance);
+
+// 
+void mVector4Invert(Vector4 *out, Vector4 *v);
+
+// 
+int mVector4Equals(Vector4 *p, Vector4 *q);
 
 // 
 float mMatrixDeterminant(Matrix *mat);
@@ -2344,7 +2461,7 @@ void mMatrixRotateZYX(Matrix *out, Vector3 *angle);
 void mMatrixScale(Matrix *out, float x, float y, float z);
 
 // 
-void mMatrixFrustum(Matrix *out, double left, double right, double bottom, double top, double near, double far);
+void mMatrixFrustum(Matrix *out, double left, double right, double bottom, double top, double nearPlane, double farPlane);
 
 // 
 void mMatrixPerspective(Matrix *out, double fovY, double aspect, double nearPlane, double farPlane);
@@ -2399,6 +2516,9 @@ void mQuaternionNlerp(Vector4 *out, Vector4 *q1, Vector4 *q2, float amount);
 
 // 
 void mQuaternionSlerp(Vector4 *out, Vector4 *q1, Vector4 *q2, float amount);
+
+// 
+void mQuaternionCubicHermiteSpline(Vector4 *out, Vector4 *q1, Vector4 *outTangent1, Vector4 *q2, Vector4 *inTangent2, float t);
 
 // 
 void mQuaternionFromVector3ToVector3(Vector4 *out, Vector3 *from, Vector3 *to);

--- a/raylib.json
+++ b/raylib.json
@@ -9,19 +9,19 @@
     {
       "name": "RAYLIB_VERSION_MAJOR",
       "type": "INT",
-      "value": "5",
+      "value": 5,
       "description": ""
     },
     {
       "name": "RAYLIB_VERSION_MINOR",
       "type": "INT",
-      "value": "1",
+      "value": 1,
       "description": ""
     },
     {
       "name": "RAYLIB_VERSION_PATCH",
       "type": "INT",
-      "value": "0",
+      "value": 0,
       "description": ""
     },
     {
@@ -45,7 +45,7 @@
     {
       "name": "PI",
       "type": "FLOAT",
-      "value": "3.14159265358979323846",
+      "value": 3.14159265358979323846,
       "description": ""
     },
     {
@@ -335,6 +335,12 @@
       "type": "UNKNOWN",
       "value": "SHADER_LOC_MAP_METALNESS",
       "description": ""
+    },
+    {
+      "name": "GetMouseRay",
+      "type": "UNKNOWN",
+      "value": "GetScreenToWorldRay",
+      "description": "Compatibility hack for previous raylib versions"
     }
   ],
   "structs": [
@@ -2069,7 +2075,7 @@
         },
         {
           "name": "KEY_MENU",
-          "value": 82,
+          "value": 5,
           "description": "Key: Android menu button"
         },
         {
@@ -2223,7 +2229,7 @@
         {
           "name": "GAMEPAD_BUTTON_RIGHT_FACE_RIGHT",
           "value": 6,
-          "description": "Gamepad right button right (i.e. PS3: Square, Xbox: X)"
+          "description": "Gamepad right button right (i.e. PS3: Circle, Xbox: B)"
         },
         {
           "name": "GAMEPAD_BUTTON_RIGHT_FACE_DOWN",
@@ -2233,7 +2239,7 @@
         {
           "name": "GAMEPAD_BUTTON_RIGHT_FACE_LEFT",
           "value": 8,
-          "description": "Gamepad right button left (i.e. PS3: Circle, Xbox: B)"
+          "description": "Gamepad right button left (i.e. PS3: Square, Xbox: X)"
         },
         {
           "name": "GAMEPAD_BUTTON_LEFT_TRIGGER_1",
@@ -2248,7 +2254,7 @@
         {
           "name": "GAMEPAD_BUTTON_RIGHT_TRIGGER_1",
           "value": 11,
-          "description": "Gamepad top/back trigger right (one), it could be a trailing button"
+          "description": "Gamepad top/back trigger right (first), it could be a trailing button"
         },
         {
           "name": "GAMEPAD_BUTTON_RIGHT_TRIGGER_2",
@@ -2951,27 +2957,27 @@
         {
           "name": "CAMERA_CUSTOM",
           "value": 0,
-          "description": "Custom camera"
+          "description": "Camera custom, controlled by user (UpdateCamera() does nothing)"
         },
         {
           "name": "CAMERA_FREE",
           "value": 1,
-          "description": "Free camera"
+          "description": "Camera free mode"
         },
         {
           "name": "CAMERA_ORBITAL",
           "value": 2,
-          "description": "Orbital camera"
+          "description": "Camera orbital, around target, zoom supported"
         },
         {
           "name": "CAMERA_FIRST_PERSON",
           "value": 3,
-          "description": "First person camera"
+          "description": "Camera first person"
         },
         {
           "name": "CAMERA_THIRD_PERSON",
           "value": 4,
-          "description": "Third person camera"
+          "description": "Camera third person"
         }
       ]
     },
@@ -3872,13 +3878,13 @@
       ]
     },
     {
-      "name": "GetMouseRay",
-      "description": "Get a ray trace from mouse position",
+      "name": "GetScreenToWorldRay",
+      "description": "Get a ray trace from screen position (i.e mouse)",
       "returnType": "Ray",
       "params": [
         {
           "type": "Vector2",
-          "name": "mousePosition"
+          "name": "position"
         },
         {
           "type": "Camera",
@@ -3887,24 +3893,25 @@
       ]
     },
     {
-      "name": "GetCameraMatrix",
-      "description": "Get camera transform matrix (view matrix)",
-      "returnType": "Matrix",
+      "name": "GetScreenToWorldRayEx",
+      "description": "Get a ray trace from screen position (i.e mouse) in a viewport",
+      "returnType": "Ray",
       "params": [
+        {
+          "type": "Vector2",
+          "name": "position"
+        },
         {
           "type": "Camera",
           "name": "camera"
-        }
-      ]
-    },
-    {
-      "name": "GetCameraMatrix2D",
-      "description": "Get camera 2d transform matrix",
-      "returnType": "Matrix",
-      "params": [
+        },
         {
-          "type": "Camera2D",
-          "name": "camera"
+          "type": "int",
+          "name": "width"
+        },
+        {
+          "type": "int",
+          "name": "height"
         }
       ]
     },
@@ -3919,21 +3926,6 @@
         },
         {
           "type": "Camera",
-          "name": "camera"
-        }
-      ]
-    },
-    {
-      "name": "GetScreenToWorld2D",
-      "description": "Get the world space position for a 2d camera screen space position",
-      "returnType": "Vector2",
-      "params": [
-        {
-          "type": "Vector2",
-          "name": "position"
-        },
-        {
-          "type": "Camera2D",
           "name": "camera"
         }
       ]
@@ -3970,6 +3962,43 @@
           "type": "Vector2",
           "name": "position"
         },
+        {
+          "type": "Camera2D",
+          "name": "camera"
+        }
+      ]
+    },
+    {
+      "name": "GetScreenToWorld2D",
+      "description": "Get the world space position for a 2d camera screen space position",
+      "returnType": "Vector2",
+      "params": [
+        {
+          "type": "Vector2",
+          "name": "position"
+        },
+        {
+          "type": "Camera2D",
+          "name": "camera"
+        }
+      ]
+    },
+    {
+      "name": "GetCameraMatrix",
+      "description": "Get camera transform matrix (view matrix)",
+      "returnType": "Matrix",
+      "params": [
+        {
+          "type": "Camera",
+          "name": "camera"
+        }
+      ]
+    },
+    {
+      "name": "GetCameraMatrix2D",
+      "description": "Get camera 2d transform matrix",
+      "returnType": "Matrix",
+      "params": [
         {
           "type": "Camera2D",
           "name": "camera"
@@ -4471,6 +4500,17 @@
       ]
     },
     {
+      "name": "IsFileNameValid",
+      "description": "Check if fileName is valid for the platform/OS",
+      "returnType": "bool",
+      "params": [
+        {
+          "type": "const char *",
+          "name": "fileName"
+        }
+      ]
+    },
+    {
       "name": "LoadDirectoryFiles",
       "description": "Load directory filepaths",
       "returnType": "FilePathList",
@@ -4896,6 +4936,25 @@
       ]
     },
     {
+      "name": "SetGamepadVibration",
+      "description": "Set gamepad vibration for both motors",
+      "returnType": "void",
+      "params": [
+        {
+          "type": "int",
+          "name": "gamepad"
+        },
+        {
+          "type": "float",
+          "name": "leftMotor"
+        },
+        {
+          "type": "float",
+          "name": "rightMotor"
+        }
+      ]
+    },
+    {
       "name": "IsMouseButtonPressed",
       "description": "Check if a mouse button has been pressed once",
       "returnType": "bool",
@@ -5286,7 +5345,7 @@
       "returnType": "void",
       "params": [
         {
-          "type": "Vector2 *",
+          "type": "const Vector2 *",
           "name": "points"
         },
         {
@@ -5863,6 +5922,29 @@
     },
     {
       "name": "DrawRectangleRoundedLines",
+      "description": "Draw rectangle lines with rounded edges",
+      "returnType": "void",
+      "params": [
+        {
+          "type": "Rectangle",
+          "name": "rec"
+        },
+        {
+          "type": "float",
+          "name": "roundness"
+        },
+        {
+          "type": "int",
+          "name": "segments"
+        },
+        {
+          "type": "Color",
+          "name": "color"
+        }
+      ]
+    },
+    {
+      "name": "DrawRectangleRoundedLinesEx",
       "description": "Draw rectangle with rounded edges outline",
       "returnType": "void",
       "params": [
@@ -5940,7 +6022,7 @@
       "returnType": "void",
       "params": [
         {
-          "type": "Vector2 *",
+          "type": "const Vector2 *",
           "name": "points"
         },
         {
@@ -5959,7 +6041,7 @@
       "returnType": "void",
       "params": [
         {
-          "type": "Vector2 *",
+          "type": "const Vector2 *",
           "name": "points"
         },
         {
@@ -6063,7 +6145,7 @@
       "returnType": "void",
       "params": [
         {
-          "type": "Vector2 *",
+          "type": "const Vector2 *",
           "name": "points"
         },
         {
@@ -6086,7 +6168,7 @@
       "returnType": "void",
       "params": [
         {
-          "type": "Vector2 *",
+          "type": "const Vector2 *",
           "name": "points"
         },
         {
@@ -6109,7 +6191,7 @@
       "returnType": "void",
       "params": [
         {
-          "type": "Vector2 *",
+          "type": "const Vector2 *",
           "name": "points"
         },
         {
@@ -6132,7 +6214,7 @@
       "returnType": "void",
       "params": [
         {
-          "type": "Vector2 *",
+          "type": "const Vector2 *",
           "name": "points"
         },
         {
@@ -6155,7 +6237,7 @@
       "returnType": "void",
       "params": [
         {
-          "type": "Vector2 *",
+          "type": "const Vector2 *",
           "name": "points"
         },
         {
@@ -6562,7 +6644,7 @@
           "name": "point"
         },
         {
-          "type": "Vector2 *",
+          "type": "const Vector2 *",
           "name": "points"
         },
         {
@@ -6618,6 +6700,29 @@
         {
           "type": "int",
           "name": "threshold"
+        }
+      ]
+    },
+    {
+      "name": "CheckCollisionCircleLine",
+      "description": "Check if circle collides with a line created betweeen two points [p1] and [p2]",
+      "returnType": "bool",
+      "params": [
+        {
+          "type": "Vector2",
+          "name": "center"
+        },
+        {
+          "type": "float",
+          "name": "radius"
+        },
+        {
+          "type": "Vector2",
+          "name": "p1"
+        },
+        {
+          "type": "Vector2",
+          "name": "p2"
         }
       ]
     },
@@ -8327,6 +8432,21 @@
       ]
     },
     {
+      "name": "ColorIsEqual",
+      "description": "Check if two colors are equal",
+      "returnType": "bool",
+      "params": [
+        {
+          "type": "Color",
+          "name": "col1"
+        },
+        {
+          "type": "Color",
+          "name": "col2"
+        }
+      ]
+    },
+    {
       "name": "Fade",
       "description": "Get color with alpha applied, alpha goes from 0.0f to 1.0f",
       "returnType": "Color",
@@ -8343,7 +8463,7 @@
     },
     {
       "name": "ColorToInt",
-      "description": "Get hexadecimal value for a Color",
+      "description": "Get hexadecimal value for a Color (0xRRGGBBAA)",
       "returnType": "int",
       "params": [
         {
@@ -9360,6 +9480,28 @@
       ]
     },
     {
+      "name": "TextToSnake",
+      "description": "Get Snake case notation version of provided string",
+      "returnType": "const char *",
+      "params": [
+        {
+          "type": "const char *",
+          "name": "text"
+        }
+      ]
+    },
+    {
+      "name": "TextToCamel",
+      "description": "Get Camel case notation version of provided string",
+      "returnType": "const char *",
+      "params": [
+        {
+          "type": "const char *",
+          "name": "text"
+        }
+      ]
+    },
+    {
       "name": "TextToInteger",
       "description": "Get integer value from text (negative values not supported)",
       "returnType": "int",
@@ -9471,7 +9613,7 @@
       "returnType": "void",
       "params": [
         {
-          "type": "Vector3 *",
+          "type": "const Vector3 *",
           "name": "points"
         },
         {
@@ -11145,7 +11287,7 @@
     },
     {
       "name": "WaveCrop",
-      "description": "Crop a wave to defined samples range",
+      "description": "Crop a wave to defined frames range",
       "returnType": "void",
       "params": [
         {
@@ -11154,11 +11296,11 @@
         },
         {
           "type": "int",
-          "name": "initSample"
+          "name": "initFrame"
         },
         {
           "type": "int",
-          "name": "finalSample"
+          "name": "finalFrame"
         }
       ]
     },
@@ -11606,7 +11748,7 @@
     },
     {
       "name": "AttachAudioStreamProcessor",
-      "description": "Attach audio stream processor to stream, receives the samples as <float>s",
+      "description": "Attach audio stream processor to stream, receives the samples as 'float'",
       "returnType": "void",
       "params": [
         {
@@ -11636,7 +11778,7 @@
     },
     {
       "name": "AttachAudioMixedProcessor",
-      "description": "Attach audio stream processor to the entire audio pipeline, receives the samples as <float>s",
+      "description": "Attach audio stream processor to the entire audio pipeline, receives the samples as 'float'",
       "returnType": "void",
       "params": [
         {

--- a/raylib.zig
+++ b/raylib.zig
@@ -1313,12 +1313,11 @@ pub fn GetWindowScaleDPI() Vector2 {
 pub fn GetMonitorName(
     monitor: i32,
 ) [*:0]const u8 {
-    return @as(
-        [*:0]const u8,
-        @ptrCast(raylib.mGetMonitorName(
+    return @as([*:0]const u8, @ptrCast(
+        raylib.mGetMonitorName(
             monitor,
-        )),
-    );
+        ),
+    ));
 }
 
 /// Set clipboard text content
@@ -1332,10 +1331,9 @@ pub fn SetClipboardText(
 
 /// Get clipboard text content
 pub fn GetClipboardText() [*:0]const u8 {
-    return @as(
-        [*:0]const u8,
-        @ptrCast(raylib.mGetClipboardText()),
-    );
+    return @as([*:0]const u8, @ptrCast(
+        raylib.mGetClipboardText(),
+    ));
 }
 
 /// Enable waiting for events on EndDrawing(), no automatic event polling
@@ -1648,40 +1646,34 @@ pub fn UnloadShader(
     );
 }
 
-/// Get a ray trace from mouse position
-pub fn GetMouseRay(
-    mousePosition: Vector2,
+/// Get a ray trace from screen position (i.e mouse)
+pub fn GetScreenToWorldRay(
+    position: Vector2,
     camera: Camera3D,
 ) Ray {
     var out: Ray = undefined;
-    raylib.mGetMouseRay(
+    raylib.mGetScreenToWorldRay(
         @as([*c]raylib.Ray, @ptrCast(&out)),
-        @as([*c]raylib.Vector2, @ptrFromInt(@intFromPtr(&mousePosition))),
+        @as([*c]raylib.Vector2, @ptrFromInt(@intFromPtr(&position))),
         @as([*c]raylib.Camera3D, @ptrFromInt(@intFromPtr(&camera))),
     );
     return out;
 }
 
-/// Get camera transform matrix (view matrix)
-pub fn GetCameraMatrix(
+/// Get a ray trace from screen position (i.e mouse) in a viewport
+pub fn GetScreenToWorldRayEx(
+    position: Vector2,
     camera: Camera3D,
-) Matrix {
-    var out: Matrix = undefined;
-    raylib.mGetCameraMatrix(
-        @as([*c]raylib.Matrix, @ptrCast(&out)),
+    width: i32,
+    height: i32,
+) Ray {
+    var out: Ray = undefined;
+    raylib.mGetScreenToWorldRayEx(
+        @as([*c]raylib.Ray, @ptrCast(&out)),
+        @as([*c]raylib.Vector2, @ptrFromInt(@intFromPtr(&position))),
         @as([*c]raylib.Camera3D, @ptrFromInt(@intFromPtr(&camera))),
-    );
-    return out;
-}
-
-/// Get camera 2d transform matrix
-pub fn GetCameraMatrix2D(
-    camera: Camera2D,
-) Matrix {
-    var out: Matrix = undefined;
-    raylib.mGetCameraMatrix2D(
-        @as([*c]raylib.Matrix, @ptrCast(&out)),
-        @as([*c]raylib.Camera2D, @ptrFromInt(@intFromPtr(&camera))),
+        width,
+        height,
     );
     return out;
 }
@@ -1696,20 +1688,6 @@ pub fn GetWorldToScreen(
         @as([*c]raylib.Vector2, @ptrCast(&out)),
         @as([*c]raylib.Vector3, @ptrFromInt(@intFromPtr(&position))),
         @as([*c]raylib.Camera3D, @ptrFromInt(@intFromPtr(&camera))),
-    );
-    return out;
-}
-
-/// Get the world space position for a 2d camera screen space position
-pub fn GetScreenToWorld2D(
-    position: Vector2,
-    camera: Camera2D,
-) Vector2 {
-    var out: Vector2 = undefined;
-    raylib.mGetScreenToWorld2D(
-        @as([*c]raylib.Vector2, @ptrCast(&out)),
-        @as([*c]raylib.Vector2, @ptrFromInt(@intFromPtr(&position))),
-        @as([*c]raylib.Camera2D, @ptrFromInt(@intFromPtr(&camera))),
     );
     return out;
 }
@@ -1741,6 +1719,44 @@ pub fn GetWorldToScreen2D(
     raylib.mGetWorldToScreen2D(
         @as([*c]raylib.Vector2, @ptrCast(&out)),
         @as([*c]raylib.Vector2, @ptrFromInt(@intFromPtr(&position))),
+        @as([*c]raylib.Camera2D, @ptrFromInt(@intFromPtr(&camera))),
+    );
+    return out;
+}
+
+/// Get the world space position for a 2d camera screen space position
+pub fn GetScreenToWorld2D(
+    position: Vector2,
+    camera: Camera2D,
+) Vector2 {
+    var out: Vector2 = undefined;
+    raylib.mGetScreenToWorld2D(
+        @as([*c]raylib.Vector2, @ptrCast(&out)),
+        @as([*c]raylib.Vector2, @ptrFromInt(@intFromPtr(&position))),
+        @as([*c]raylib.Camera2D, @ptrFromInt(@intFromPtr(&camera))),
+    );
+    return out;
+}
+
+/// Get camera transform matrix (view matrix)
+pub fn GetCameraMatrix(
+    camera: Camera3D,
+) Matrix {
+    var out: Matrix = undefined;
+    raylib.mGetCameraMatrix(
+        @as([*c]raylib.Matrix, @ptrCast(&out)),
+        @as([*c]raylib.Camera3D, @ptrFromInt(@intFromPtr(&camera))),
+    );
+    return out;
+}
+
+/// Get camera 2d transform matrix
+pub fn GetCameraMatrix2D(
+    camera: Camera2D,
+) Matrix {
+    var out: Matrix = undefined;
+    raylib.mGetCameraMatrix2D(
+        @as([*c]raylib.Matrix, @ptrCast(&out)),
         @as([*c]raylib.Camera2D, @ptrFromInt(@intFromPtr(&camera))),
     );
     return out;
@@ -1815,14 +1831,13 @@ pub fn LoadRandomSequence(
     min: i32,
     max: i32,
 ) ?[*]i32 {
-    return @as(
-        ?[*]i32,
-        @ptrCast(raylib.mLoadRandomSequence(
+    return @as(?[*]i32, @ptrCast(
+        raylib.mLoadRandomSequence(
             count,
             min,
             max,
-        )),
-    );
+        ),
+    ));
 }
 
 /// Unload random values sequence
@@ -1927,12 +1942,11 @@ pub fn ExportDataAsCode(
 pub fn LoadFileText(
     fileName: [*:0]const u8,
 ) [*:0]const u8 {
-    return @as(
-        ?[*]u8,
-        @ptrCast(raylib.mLoadFileText(
+    return @as(?[*]u8, @ptrCast(
+        raylib.mLoadFileText(
             @as([*c]const u8, @ptrFromInt(@intFromPtr(fileName))),
-        )),
-    );
+        ),
+    ));
 }
 
 /// Unload file text data allocated by LoadFileText()
@@ -1997,76 +2011,69 @@ pub fn GetFileLength(
 pub fn GetFileExtension(
     fileName: [*:0]const u8,
 ) [*:0]const u8 {
-    return @as(
-        [*:0]const u8,
-        @ptrCast(raylib.mGetFileExtension(
+    return @as([*:0]const u8, @ptrCast(
+        raylib.mGetFileExtension(
             @as([*c]const u8, @ptrFromInt(@intFromPtr(fileName))),
-        )),
-    );
+        ),
+    ));
 }
 
 /// Get pointer to filename for a path string
 pub fn GetFileName(
     filePath: [*:0]const u8,
 ) [*:0]const u8 {
-    return @as(
-        [*:0]const u8,
-        @ptrCast(raylib.mGetFileName(
+    return @as([*:0]const u8, @ptrCast(
+        raylib.mGetFileName(
             @as([*c]const u8, @ptrFromInt(@intFromPtr(filePath))),
-        )),
-    );
+        ),
+    ));
 }
 
 /// Get filename string without extension (uses static string)
 pub fn GetFileNameWithoutExt(
     filePath: [*:0]const u8,
 ) [*:0]const u8 {
-    return @as(
-        [*:0]const u8,
-        @ptrCast(raylib.mGetFileNameWithoutExt(
+    return @as([*:0]const u8, @ptrCast(
+        raylib.mGetFileNameWithoutExt(
             @as([*c]const u8, @ptrFromInt(@intFromPtr(filePath))),
-        )),
-    );
+        ),
+    ));
 }
 
 /// Get full path for a given fileName with path (uses static string)
 pub fn GetDirectoryPath(
     filePath: [*:0]const u8,
 ) [*:0]const u8 {
-    return @as(
-        [*:0]const u8,
-        @ptrCast(raylib.mGetDirectoryPath(
+    return @as([*:0]const u8, @ptrCast(
+        raylib.mGetDirectoryPath(
             @as([*c]const u8, @ptrFromInt(@intFromPtr(filePath))),
-        )),
-    );
+        ),
+    ));
 }
 
 /// Get previous directory path for a given path (uses static string)
 pub fn GetPrevDirectoryPath(
     dirPath: [*:0]const u8,
 ) [*:0]const u8 {
-    return @as(
-        [*:0]const u8,
-        @ptrCast(raylib.mGetPrevDirectoryPath(
+    return @as([*:0]const u8, @ptrCast(
+        raylib.mGetPrevDirectoryPath(
             @as([*c]const u8, @ptrFromInt(@intFromPtr(dirPath))),
-        )),
-    );
+        ),
+    ));
 }
 
 /// Get current working directory (uses static string)
 pub fn GetWorkingDirectory() [*:0]const u8 {
-    return @as(
-        [*:0]const u8,
-        @ptrCast(raylib.mGetWorkingDirectory()),
-    );
+    return @as([*:0]const u8, @ptrCast(
+        raylib.mGetWorkingDirectory(),
+    ));
 }
 
 /// Get the directory of the running application (uses static string)
 pub fn GetApplicationDirectory() [*:0]const u8 {
-    return @as(
-        [*:0]const u8,
-        @ptrCast(raylib.mGetApplicationDirectory()),
-    );
+    return @as([*:0]const u8, @ptrCast(
+        raylib.mGetApplicationDirectory(),
+    ));
 }
 
 /// Change working directory, return true on success
@@ -2084,6 +2091,15 @@ pub fn IsPathFile(
 ) bool {
     return raylib.mIsPathFile(
         @as([*c]const u8, @ptrFromInt(@intFromPtr(path))),
+    );
+}
+
+/// Check if fileName is valid for the platform/OS
+pub fn IsFileNameValid(
+    fileName: [*:0]const u8,
+) bool {
+    return raylib.mIsFileNameValid(
+        @as([*c]const u8, @ptrFromInt(@intFromPtr(fileName))),
     );
 }
 
@@ -2162,14 +2178,13 @@ pub fn CompressData(
     dataSize: i32,
     compDataSize: ?[*]i32,
 ) [*:0]const u8 {
-    return @as(
-        ?[*]u8,
-        @ptrCast(raylib.mCompressData(
+    return @as(?[*]u8, @ptrCast(
+        raylib.mCompressData(
             @as([*c]const u8, @ptrFromInt(@intFromPtr(data))),
             dataSize,
             @as([*c]i32, @ptrCast(compDataSize)),
-        )),
-    );
+        ),
+    ));
 }
 
 /// Decompress data (DEFLATE algorithm), memory must be MemFree()
@@ -2178,14 +2193,13 @@ pub fn DecompressData(
     compDataSize: i32,
     dataSize: ?[*]i32,
 ) [*:0]const u8 {
-    return @as(
-        ?[*]u8,
-        @ptrCast(raylib.mDecompressData(
+    return @as(?[*]u8, @ptrCast(
+        raylib.mDecompressData(
             @as([*c]const u8, @ptrFromInt(@intFromPtr(compData))),
             compDataSize,
             @as([*c]i32, @ptrCast(dataSize)),
-        )),
-    );
+        ),
+    ));
 }
 
 /// Encode data to Base64 string, memory must be MemFree()
@@ -2194,14 +2208,13 @@ pub fn EncodeDataBase64(
     dataSize: i32,
     outputSize: ?[*]i32,
 ) [*:0]const u8 {
-    return @as(
-        ?[*]u8,
-        @ptrCast(raylib.mEncodeDataBase64(
+    return @as(?[*]u8, @ptrCast(
+        raylib.mEncodeDataBase64(
             @as([*c]const u8, @ptrFromInt(@intFromPtr(data))),
             dataSize,
             @as([*c]i32, @ptrCast(outputSize)),
-        )),
-    );
+        ),
+    ));
 }
 
 /// Decode Base64 string data, memory must be MemFree()
@@ -2209,13 +2222,12 @@ pub fn DecodeDataBase64(
     data: [*:0]const u8,
     outputSize: ?[*]i32,
 ) [*:0]const u8 {
-    return @as(
-        ?[*]u8,
-        @ptrCast(raylib.mDecodeDataBase64(
+    return @as(?[*]u8, @ptrCast(
+        raylib.mDecodeDataBase64(
             @as([*c]const u8, @ptrFromInt(@intFromPtr(data))),
             @as([*c]i32, @ptrCast(outputSize)),
-        )),
-    );
+        ),
+    ));
 }
 
 /// Load automation events list from file, NULL for empty list, capacity = MAX_AUTOMATION_EVENTS
@@ -2364,12 +2376,11 @@ pub fn IsGamepadAvailable(
 pub fn GetGamepadName(
     gamepad: i32,
 ) [*:0]const u8 {
-    return @as(
-        [*:0]const u8,
-        @ptrCast(raylib.mGetGamepadName(
+    return @as([*:0]const u8, @ptrCast(
+        raylib.mGetGamepadName(
             gamepad,
-        )),
-    );
+        ),
+    ));
 }
 
 /// Check if a gamepad button has been pressed once
@@ -2442,6 +2453,19 @@ pub fn SetGamepadMappings(
 ) i32 {
     return raylib.mSetGamepadMappings(
         @as([*c]const u8, @ptrFromInt(@intFromPtr(mappings))),
+    );
+}
+
+/// Set gamepad vibration for both motors
+pub fn SetGamepadVibration(
+    gamepad: i32,
+    leftMotor: f32,
+    rightMotor: f32,
+) void {
+    raylib.mSetGamepadVibration(
+        gamepad,
+        leftMotor,
+        rightMotor,
     );
 }
 
@@ -2783,7 +2807,7 @@ pub fn DrawLineEx(
 
 /// Draw lines sequence (using gl lines)
 pub fn DrawLineStrip(
-    points: ?[*]Vector2,
+    points: ?[*]const Vector2,
     pointCount: i32,
     color: Color,
 ) void {
@@ -3152,15 +3176,30 @@ pub fn DrawRectangleRounded(
     );
 }
 
-/// Draw rectangle with rounded edges outline
+/// Draw rectangle lines with rounded edges
 pub fn DrawRectangleRoundedLines(
+    rec: Rectangle,
+    roundness: f32,
+    segments: i32,
+    color: Color,
+) void {
+    raylib.mDrawRectangleRoundedLines(
+        @as([*c]raylib.Rectangle, @ptrFromInt(@intFromPtr(&rec))),
+        roundness,
+        segments,
+        @as([*c]raylib.Color, @ptrFromInt(@intFromPtr(&color))),
+    );
+}
+
+/// Draw rectangle with rounded edges outline
+pub fn DrawRectangleRoundedLinesEx(
     rec: Rectangle,
     roundness: f32,
     segments: i32,
     lineThick: f32,
     color: Color,
 ) void {
-    raylib.mDrawRectangleRoundedLines(
+    raylib.mDrawRectangleRoundedLinesEx(
         @as([*c]raylib.Rectangle, @ptrFromInt(@intFromPtr(&rec))),
         roundness,
         segments,
@@ -3201,7 +3240,7 @@ pub fn DrawTriangleLines(
 
 /// Draw a triangle fan defined by points (first vertex is the center)
 pub fn DrawTriangleFan(
-    points: ?[*]Vector2,
+    points: ?[*]const Vector2,
     pointCount: i32,
     color: Color,
 ) void {
@@ -3214,7 +3253,7 @@ pub fn DrawTriangleFan(
 
 /// Draw a triangle strip defined by points
 pub fn DrawTriangleStrip(
-    points: ?[*]Vector2,
+    points: ?[*]const Vector2,
     pointCount: i32,
     color: Color,
 ) void {
@@ -3280,7 +3319,7 @@ pub fn DrawPolyLinesEx(
 
 /// Draw spline: Linear, minimum 2 points
 pub fn DrawSplineLinear(
-    points: ?[*]Vector2,
+    points: ?[*]const Vector2,
     pointCount: i32,
     thick: f32,
     color: Color,
@@ -3295,7 +3334,7 @@ pub fn DrawSplineLinear(
 
 /// Draw spline: B-Spline, minimum 4 points
 pub fn DrawSplineBasis(
-    points: ?[*]Vector2,
+    points: ?[*]const Vector2,
     pointCount: i32,
     thick: f32,
     color: Color,
@@ -3310,7 +3349,7 @@ pub fn DrawSplineBasis(
 
 /// Draw spline: Catmull-Rom, minimum 4 points
 pub fn DrawSplineCatmullRom(
-    points: ?[*]Vector2,
+    points: ?[*]const Vector2,
     pointCount: i32,
     thick: f32,
     color: Color,
@@ -3325,7 +3364,7 @@ pub fn DrawSplineCatmullRom(
 
 /// Draw spline: Quadratic Bezier, minimum 3 points (1 control point): [p1, c2, p3, c4...]
 pub fn DrawSplineBezierQuadratic(
-    points: ?[*]Vector2,
+    points: ?[*]const Vector2,
     pointCount: i32,
     thick: f32,
     color: Color,
@@ -3340,7 +3379,7 @@ pub fn DrawSplineBezierQuadratic(
 
 /// Draw spline: Cubic Bezier, minimum 4 points (2 control points): [p1, c2, c3, p4, c5, c6...]
 pub fn DrawSplineBezierCubic(
-    points: ?[*]Vector2,
+    points: ?[*]const Vector2,
     pointCount: i32,
     thick: f32,
     color: Color,
@@ -3617,7 +3656,7 @@ pub fn CheckCollisionPointTriangle(
 /// Check if point is within a polygon described by array of vertices
 pub fn CheckCollisionPointPoly(
     point: Vector2,
-    points: ?[*]Vector2,
+    points: ?[*]const Vector2,
     pointCount: i32,
 ) bool {
     return raylib.mCheckCollisionPointPoly(
@@ -3656,6 +3695,21 @@ pub fn CheckCollisionPointLine(
         @as([*c]raylib.Vector2, @ptrFromInt(@intFromPtr(&p1))),
         @as([*c]raylib.Vector2, @ptrFromInt(@intFromPtr(&p2))),
         threshold,
+    );
+}
+
+/// Check if circle collides with a line created betweeen two points [p1] and [p2]
+pub fn CheckCollisionCircleLine(
+    center: Vector2,
+    radius: f32,
+    p1: Vector2,
+    p2: Vector2,
+) bool {
+    return raylib.mCheckCollisionCircleLine(
+        @as([*c]raylib.Vector2, @ptrFromInt(@intFromPtr(&center))),
+        radius,
+        @as([*c]raylib.Vector2, @ptrFromInt(@intFromPtr(&p1))),
+        @as([*c]raylib.Vector2, @ptrFromInt(@intFromPtr(&p2))),
     );
 }
 
@@ -3825,14 +3879,13 @@ pub fn ExportImageToMemory(
     fileType: [*:0]const u8,
     fileSize: ?[*]i32,
 ) [*:0]const u8 {
-    return @as(
-        ?[*]u8,
-        @ptrCast(raylib.mExportImageToMemory(
+    return @as(?[*]u8, @ptrCast(
+        raylib.mExportImageToMemory(
             @as([*c]raylib.Image, @ptrFromInt(@intFromPtr(&image))),
             @as([*c]const u8, @ptrFromInt(@intFromPtr(fileType))),
             @as([*c]i32, @ptrCast(fileSize)),
-        )),
-    );
+        ),
+    ));
 }
 
 /// Export image as code file defining an array of bytes, returns true on success
@@ -4361,12 +4414,11 @@ pub fn ImageColorReplace(
 pub fn LoadImageColors(
     image: Image,
 ) ?[*]Color {
-    return @as(
-        ?[*]Color,
-        @ptrCast(raylib.mLoadImageColors(
+    return @as(?[*]Color, @ptrCast(
+        raylib.mLoadImageColors(
             @as([*c]raylib.Image, @ptrFromInt(@intFromPtr(&image))),
-        )),
-    );
+        ),
+    ));
 }
 
 /// Load colors palette from image as a Color array (RGBA - 32bit)
@@ -4375,14 +4427,13 @@ pub fn LoadImagePalette(
     maxPaletteSize: i32,
     colorCount: ?[*]i32,
 ) ?[*]Color {
-    return @as(
-        ?[*]Color,
-        @ptrCast(raylib.mLoadImagePalette(
+    return @as(?[*]Color, @ptrCast(
+        raylib.mLoadImagePalette(
             @as([*c]raylib.Image, @ptrFromInt(@intFromPtr(&image))),
             maxPaletteSize,
             @as([*c]i32, @ptrCast(colorCount)),
-        )),
-    );
+        ),
+    ));
 }
 
 /// Unload color data loaded with LoadImageColors()
@@ -4921,6 +4972,17 @@ pub fn DrawTextureNPatch(
     );
 }
 
+/// Check if two colors are equal
+pub fn ColorIsEqual(
+    col1: Color,
+    col2: Color,
+) bool {
+    return raylib.mColorIsEqual(
+        @as([*c]raylib.Color, @ptrFromInt(@intFromPtr(&col1))),
+        @as([*c]raylib.Color, @ptrFromInt(@intFromPtr(&col2))),
+    );
+}
+
 /// Get color with alpha applied, alpha goes from 0.0f to 1.0f
 pub fn Fade(
     color: Color,
@@ -4935,7 +4997,7 @@ pub fn Fade(
     return out;
 }
 
-/// Get hexadecimal value for a Color
+/// Get hexadecimal value for a Color (0xRRGGBBAA)
 pub fn ColorToInt(
     color: Color,
 ) i32 {
@@ -5427,13 +5489,12 @@ pub fn LoadUTF8(
     codepoints: ?[*]const i32,
     length: i32,
 ) [*:0]const u8 {
-    return @as(
-        ?[*]u8,
-        @ptrCast(raylib.mLoadUTF8(
+    return @as(?[*]u8, @ptrCast(
+        raylib.mLoadUTF8(
             @as([*c]const i32, @ptrFromInt(@intFromPtr(codepoints))),
             length,
-        )),
-    );
+        ),
+    ));
 }
 
 /// Unload UTF-8 text encoded from codepoints array
@@ -5450,13 +5511,12 @@ pub fn LoadCodepoints(
     text: [*:0]const u8,
     count: ?[*]i32,
 ) ?[*]i32 {
-    return @as(
-        ?[*]i32,
-        @ptrCast(raylib.mLoadCodepoints(
+    return @as(?[*]i32, @ptrCast(
+        raylib.mLoadCodepoints(
             @as([*c]const u8, @ptrFromInt(@intFromPtr(text))),
             @as([*c]i32, @ptrCast(count)),
-        )),
-    );
+        ),
+    ));
 }
 
 /// Unload codepoints data from memory
@@ -5515,13 +5575,12 @@ pub fn CodepointToUTF8(
     codepoint: i32,
     utf8Size: ?[*]i32,
 ) [*:0]const u8 {
-    return @as(
-        [*:0]const u8,
-        @ptrCast(raylib.mCodepointToUTF8(
+    return @as([*:0]const u8, @ptrCast(
+        raylib.mCodepointToUTF8(
             codepoint,
             @as([*c]i32, @ptrCast(utf8Size)),
-        )),
-    );
+        ),
+    ));
 }
 
 /// Copy one string to another, returns bytes copied
@@ -5570,14 +5629,13 @@ pub fn TextSubtext(
     position: i32,
     length: i32,
 ) [*:0]const u8 {
-    return @as(
-        [*:0]const u8,
-        @ptrCast(raylib.mTextSubtext(
+    return @as([*:0]const u8, @ptrCast(
+        raylib.mTextSubtext(
             @as([*c]const u8, @ptrFromInt(@intFromPtr(text))),
             position,
             length,
-        )),
-    );
+        ),
+    ));
 }
 
 /// Replace text string (WARNING: memory must be freed!)
@@ -5586,14 +5644,13 @@ pub fn TextReplace(
     replace: [*:0]const u8,
     by: [*:0]const u8,
 ) [*:0]const u8 {
-    return @as(
-        ?[*]u8,
-        @ptrCast(raylib.mTextReplace(
+    return @as(?[*]u8, @ptrCast(
+        raylib.mTextReplace(
             @as([*c]const u8, @ptrFromInt(@intFromPtr(text))),
             @as([*c]const u8, @ptrFromInt(@intFromPtr(replace))),
             @as([*c]const u8, @ptrFromInt(@intFromPtr(by))),
-        )),
-    );
+        ),
+    ));
 }
 
 /// Insert text in a position (WARNING: memory must be freed!)
@@ -5602,14 +5659,13 @@ pub fn TextInsert(
     insert: [*:0]const u8,
     position: i32,
 ) [*:0]const u8 {
-    return @as(
-        ?[*]u8,
-        @ptrCast(raylib.mTextInsert(
+    return @as(?[*]u8, @ptrCast(
+        raylib.mTextInsert(
             @as([*c]const u8, @ptrFromInt(@intFromPtr(text))),
             @as([*c]const u8, @ptrFromInt(@intFromPtr(insert))),
             position,
-        )),
-    );
+        ),
+    ));
 }
 
 /// Load font data for further use
@@ -5621,17 +5677,16 @@ pub fn LoadFontData(
     glyphCount: i32,
     typ: i32,
 ) [*]GlyphInfo {
-    return @as(
-        [*]GlyphInfo,
-        @ptrCast(raylib.mLoadFontData(
+    return @as([*]GlyphInfo, @ptrCast(
+        raylib.mLoadFontData(
             @as([*c]const u8, @ptrFromInt(@intFromPtr(fileData))),
             dataSize,
             fontSize,
             @as([*c]i32, @ptrCast(fontChars)),
             glyphCount,
             typ,
-        )),
-    );
+        ),
+    ));
 }
 
 ///
@@ -5668,36 +5723,55 @@ pub fn TextFindIndex(
 pub fn TextToUpper(
     text: [*:0]const u8,
 ) [*:0]const u8 {
-    return @as(
-        [*:0]const u8,
-        @ptrCast(raylib.mTextToUpper(
+    return @as([*:0]const u8, @ptrCast(
+        raylib.mTextToUpper(
             @as([*c]const u8, @ptrFromInt(@intFromPtr(text))),
-        )),
-    );
+        ),
+    ));
 }
 
 /// Get lower case version of provided string
 pub fn TextToLower(
     text: [*:0]const u8,
 ) [*:0]const u8 {
-    return @as(
-        [*:0]const u8,
-        @ptrCast(raylib.mTextToLower(
+    return @as([*:0]const u8, @ptrCast(
+        raylib.mTextToLower(
             @as([*c]const u8, @ptrFromInt(@intFromPtr(text))),
-        )),
-    );
+        ),
+    ));
 }
 
 /// Get Pascal case notation version of provided string
 pub fn TextToPascal(
     text: [*:0]const u8,
 ) [*:0]const u8 {
-    return @as(
-        [*:0]const u8,
-        @ptrCast(raylib.mTextToPascal(
+    return @as([*:0]const u8, @ptrCast(
+        raylib.mTextToPascal(
             @as([*c]const u8, @ptrFromInt(@intFromPtr(text))),
-        )),
-    );
+        ),
+    ));
+}
+
+/// Get Snake case notation version of provided string
+pub fn TextToSnake(
+    text: [*:0]const u8,
+) [*:0]const u8 {
+    return @as([*:0]const u8, @ptrCast(
+        raylib.mTextToSnake(
+            @as([*c]const u8, @ptrFromInt(@intFromPtr(text))),
+        ),
+    ));
+}
+
+/// Get Camel case notation version of provided string
+pub fn TextToCamel(
+    text: [*:0]const u8,
+) [*:0]const u8 {
+    return @as([*:0]const u8, @ptrCast(
+        raylib.mTextToCamel(
+            @as([*c]const u8, @ptrFromInt(@intFromPtr(text))),
+        ),
+    ));
 }
 
 /// Get integer value from text (negative values not supported)
@@ -5776,7 +5850,7 @@ pub fn DrawTriangle3D(
 
 /// Draw a triangle strip defined by points
 pub fn DrawTriangleStrip3D(
-    points: ?[*]Vector3,
+    points: ?[*]const Vector3,
     pointCount: i32,
     color: Color,
 ) void {
@@ -6526,13 +6600,12 @@ pub fn LoadMaterials(
     fileName: [*:0]const u8,
     materialCount: ?[*]i32,
 ) ?[*]Material {
-    return @as(
-        ?[*]Material,
-        @ptrCast(raylib.mLoadMaterials(
+    return @as(?[*]Material, @ptrCast(
+        raylib.mLoadMaterials(
             @as([*c]const u8, @ptrFromInt(@intFromPtr(fileName))),
             @as([*c]i32, @ptrCast(materialCount)),
-        )),
-    );
+        ),
+    ));
 }
 
 /// Load default material (Supports: DIFFUSE, SPECULAR, NORMAL maps)
@@ -6593,13 +6666,12 @@ pub fn LoadModelAnimations(
     fileName: [*:0]const u8,
     animCount: ?[*]i32,
 ) ?[*]ModelAnimation {
-    return @as(
-        ?[*]ModelAnimation,
-        @ptrCast(raylib.mLoadModelAnimations(
+    return @as(?[*]ModelAnimation, @ptrCast(
+        raylib.mLoadModelAnimations(
             @as([*c]const u8, @ptrFromInt(@intFromPtr(fileName))),
             @as([*c]i32, @ptrCast(animCount)),
-        )),
-    );
+        ),
+    ));
 }
 
 /// Update model animation pose
@@ -7032,16 +7104,16 @@ pub fn WaveCopy(
     return out;
 }
 
-/// Crop a wave to defined samples range
+/// Crop a wave to defined frames range
 pub fn WaveCrop(
     wave: ?[*]Wave,
-    initSample: i32,
-    finalSample: i32,
+    initFrame: i32,
+    finalFrame: i32,
 ) void {
     raylib.mWaveCrop(
         @as([*c]raylib.Wave, @ptrFromInt(@intFromPtr(wave))),
-        initSample,
-        finalSample,
+        initFrame,
+        finalFrame,
     );
 }
 
@@ -7064,12 +7136,11 @@ pub fn WaveFormat(
 pub fn LoadWaveSamples(
     wave: Wave,
 ) ?[*]f32 {
-    return @as(
-        ?[*]f32,
-        @ptrCast(raylib.mLoadWaveSamples(
+    return @as(?[*]f32, @ptrCast(
+        raylib.mLoadWaveSamples(
             @as([*c]raylib.Wave, @ptrFromInt(@intFromPtr(&wave))),
-        )),
-    );
+        ),
+    ));
 }
 
 /// Unload samples data loaded with LoadWaveSamples()
@@ -7397,7 +7468,7 @@ pub fn SetAudioStreamCallback(
     );
 }
 
-/// Attach audio stream processor to stream, receives the samples as <float>s
+/// Attach audio stream processor to stream, receives the samples as 'float'
 pub fn AttachAudioStreamProcessor(
     stream: AudioStream,
     processor: AudioCallback,
@@ -7419,7 +7490,7 @@ pub fn DetachAudioStreamProcessor(
     );
 }
 
-/// Attach audio stream processor to the entire audio pipeline, receives the samples as <float>s
+/// Attach audio stream processor to the entire audio pipeline, receives the samples as 'float'
 pub fn AttachAudioMixedProcessor(
     processor: AudioCallback,
 ) void {
@@ -7562,6 +7633,27 @@ pub fn rlViewport(
         width,
         height,
     );
+}
+
+/// Set clip planes distances
+pub fn rlSetClipPlanes(
+    nearPlane: f64,
+    farPlane: f64,
+) void {
+    raylib.mrlSetClipPlanes(
+        nearPlane,
+        farPlane,
+    );
+}
+
+/// Get cull plane distance near
+pub fn rlGetCullDistanceNear() f64 {
+    return raylib.mrlGetCullDistanceNear();
+}
+
+/// Get cull plane distance far
+pub fn rlGetCullDistanceFar() f64 {
+    return raylib.mrlGetCullDistanceFar();
 }
 
 /// Initialize drawing mode (how to organize vertex)
@@ -7829,6 +7921,11 @@ pub fn rlEnableFramebuffer(
 /// Disable render texture (fbo), return to default framebuffer
 pub fn rlDisableFramebuffer() void {
     raylib.mrlDisableFramebuffer();
+}
+
+/// Get the currently active render texture (fbo), 0 for default framebuffer
+pub fn rlGetActiveFramebuffer() u32 {
+    return raylib.mrlGetActiveFramebuffer();
 }
 
 /// Activate multiple draw color buffers
@@ -8155,10 +8252,9 @@ pub fn rlGetShaderIdDefault() u32 {
 
 /// Get default shader locations
 pub fn rlGetShaderLocsDefault() ?[*]i32 {
-    return @as(
-        ?[*]i32,
-        @ptrCast(raylib.mrlGetShaderLocsDefault()),
-    );
+    return @as(?[*]i32, @ptrCast(
+        raylib.mrlGetShaderLocsDefault(),
+    ));
 }
 
 /// Load a render batch system
@@ -8476,12 +8572,11 @@ pub fn rlGetGlTextureFormats(
 pub fn rlGetPixelFormatName(
     format: u32,
 ) [*:0]const u8 {
-    return @as(
-        [*:0]const u8,
-        @ptrCast(raylib.mrlGetPixelFormatName(
+    return @as([*:0]const u8, @ptrCast(
+        raylib.mrlGetPixelFormatName(
             format,
-        )),
-    );
+        ),
+    ));
 }
 
 /// Unload texture from GPU memory
@@ -8517,15 +8612,14 @@ pub fn rlReadTexturePixels(
     height: i32,
     format: i32,
 ) *anyopaque {
-    return @as(
-        *anyopaque,
-        @ptrCast(raylib.mrlReadTexturePixels(
+    return @as(*anyopaque, @ptrCast(
+        raylib.mrlReadTexturePixels(
             id,
             width,
             height,
             format,
-        )),
-    );
+        ),
+    ));
 }
 
 /// Read screen pixel data (color buffer)
@@ -8533,24 +8627,17 @@ pub fn rlReadScreenPixels(
     width: i32,
     height: i32,
 ) [*:0]const u8 {
-    return @as(
-        ?[*]u8,
-        @ptrCast(raylib.mrlReadScreenPixels(
+    return @as(?[*]u8, @ptrCast(
+        raylib.mrlReadScreenPixels(
             width,
             height,
-        )),
-    );
+        ),
+    ));
 }
 
 /// Load an empty framebuffer
-pub fn rlLoadFramebuffer(
-    width: i32,
-    height: i32,
-) u32 {
-    return raylib.mrlLoadFramebuffer(
-        width,
-        height,
-    );
+pub fn rlLoadFramebuffer() u32 {
+    return raylib.mrlLoadFramebuffer();
 }
 
 /// Attach texture/renderbuffer to a framebuffer
@@ -8842,7 +8929,7 @@ pub fn rlGetMatrixTransform() Matrix {
     return out;
 }
 
-///
+/// Get internal projection matrix for stereo render (selected eye)
 pub fn rlGetMatrixProjectionStereo(
     eye: i32,
 ) Matrix {
@@ -8854,7 +8941,7 @@ pub fn rlGetMatrixProjectionStereo(
     return out;
 }
 
-///
+/// Get internal view offset matrix for stereo render (selected eye)
 pub fn rlGetMatrixViewOffsetStereo(
     eye: i32,
 ) Matrix {
@@ -9254,6 +9341,34 @@ pub fn Vector2Reflect(
 }
 
 ///
+pub fn Vector2Min(
+    v1: Vector2,
+    v2: Vector2,
+) Vector2 {
+    var out: Vector2 = undefined;
+    raylib.mVector2Min(
+        @as([*c]raylib.Vector2, @ptrCast(&out)),
+        @as([*c]raylib.Vector2, @ptrFromInt(@intFromPtr(&v1))),
+        @as([*c]raylib.Vector2, @ptrFromInt(@intFromPtr(&v2))),
+    );
+    return out;
+}
+
+///
+pub fn Vector2Max(
+    v1: Vector2,
+    v2: Vector2,
+) Vector2 {
+    var out: Vector2 = undefined;
+    raylib.mVector2Max(
+        @as([*c]raylib.Vector2, @ptrCast(&out)),
+        @as([*c]raylib.Vector2, @ptrFromInt(@intFromPtr(&v1))),
+        @as([*c]raylib.Vector2, @ptrFromInt(@intFromPtr(&v2))),
+    );
+    return out;
+}
+
+///
 pub fn Vector2Rotate(
     v: Vector2,
     angle: f32,
@@ -9336,6 +9451,22 @@ pub fn Vector2Equals(
         @as([*c]raylib.Vector2, @ptrFromInt(@intFromPtr(&p))),
         @as([*c]raylib.Vector2, @ptrFromInt(@intFromPtr(&q))),
     );
+}
+
+///
+pub fn Vector2Refract(
+    v: Vector2,
+    n: Vector2,
+    r: f32,
+) Vector2 {
+    var out: Vector2 = undefined;
+    raylib.mVector2Refract(
+        @as([*c]raylib.Vector2, @ptrCast(&out)),
+        @as([*c]raylib.Vector2, @ptrFromInt(@intFromPtr(&v))),
+        @as([*c]raylib.Vector2, @ptrFromInt(@intFromPtr(&n))),
+        r,
+    );
+    return out;
 }
 
 ///
@@ -9650,6 +9781,22 @@ pub fn Vector3RotateByAxisAngle(
 }
 
 ///
+pub fn Vector3MoveTowards(
+    v: Vector3,
+    target: Vector3,
+    maxDistance: f32,
+) Vector3 {
+    var out: Vector3 = undefined;
+    raylib.mVector3MoveTowards(
+        @as([*c]raylib.Vector3, @ptrCast(&out)),
+        @as([*c]raylib.Vector3, @ptrFromInt(@intFromPtr(&v))),
+        @as([*c]raylib.Vector3, @ptrFromInt(@intFromPtr(&target))),
+        maxDistance,
+    );
+    return out;
+}
+
+///
 pub fn Vector3Lerp(
     v1: Vector3,
     v2: Vector3,
@@ -9660,6 +9807,26 @@ pub fn Vector3Lerp(
         @as([*c]raylib.Vector3, @ptrCast(&out)),
         @as([*c]raylib.Vector3, @ptrFromInt(@intFromPtr(&v1))),
         @as([*c]raylib.Vector3, @ptrFromInt(@intFromPtr(&v2))),
+        amount,
+    );
+    return out;
+}
+
+///
+pub fn Vector3CubicHermite(
+    v1: Vector3,
+    tangent1: Vector3,
+    v2: Vector3,
+    tangent2: Vector3,
+    amount: f32,
+) Vector3 {
+    var out: Vector3 = undefined;
+    raylib.mVector3CubicHermite(
+        @as([*c]raylib.Vector3, @ptrCast(&out)),
+        @as([*c]raylib.Vector3, @ptrFromInt(@intFromPtr(&v1))),
+        @as([*c]raylib.Vector3, @ptrFromInt(@intFromPtr(&tangent1))),
+        @as([*c]raylib.Vector3, @ptrFromInt(@intFromPtr(&v2))),
+        @as([*c]raylib.Vector3, @ptrFromInt(@intFromPtr(&tangent2))),
         amount,
     );
     return out;
@@ -9822,6 +9989,280 @@ pub fn Vector3Refract(
         r,
     );
     return out;
+}
+
+///
+pub fn Vector4Zero() Vector4 {
+    var out: Vector4 = undefined;
+    raylib.mVector4Zero(
+        @as([*c]raylib.Vector4, @ptrCast(&out)),
+    );
+    return out;
+}
+
+///
+pub fn Vector4One() Vector4 {
+    var out: Vector4 = undefined;
+    raylib.mVector4One(
+        @as([*c]raylib.Vector4, @ptrCast(&out)),
+    );
+    return out;
+}
+
+///
+pub fn Vector4Add(
+    v1: Vector4,
+    v2: Vector4,
+) Vector4 {
+    var out: Vector4 = undefined;
+    raylib.mVector4Add(
+        @as([*c]raylib.Vector4, @ptrCast(&out)),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v1))),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v2))),
+    );
+    return out;
+}
+
+///
+pub fn Vector4AddValue(
+    v: Vector4,
+    add: f32,
+) Vector4 {
+    var out: Vector4 = undefined;
+    raylib.mVector4AddValue(
+        @as([*c]raylib.Vector4, @ptrCast(&out)),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v))),
+        add,
+    );
+    return out;
+}
+
+///
+pub fn Vector4Subtract(
+    v1: Vector4,
+    v2: Vector4,
+) Vector4 {
+    var out: Vector4 = undefined;
+    raylib.mVector4Subtract(
+        @as([*c]raylib.Vector4, @ptrCast(&out)),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v1))),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v2))),
+    );
+    return out;
+}
+
+///
+pub fn Vector4SubtractValue(
+    v: Vector4,
+    add: f32,
+) Vector4 {
+    var out: Vector4 = undefined;
+    raylib.mVector4SubtractValue(
+        @as([*c]raylib.Vector4, @ptrCast(&out)),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v))),
+        add,
+    );
+    return out;
+}
+
+///
+pub fn Vector4Length(
+    v: Vector4,
+) f32 {
+    return raylib.mVector4Length(
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v))),
+    );
+}
+
+///
+pub fn Vector4LengthSqr(
+    v: Vector4,
+) f32 {
+    return raylib.mVector4LengthSqr(
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v))),
+    );
+}
+
+///
+pub fn Vector4DotProduct(
+    v1: Vector4,
+    v2: Vector4,
+) f32 {
+    return raylib.mVector4DotProduct(
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v1))),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v2))),
+    );
+}
+
+///
+pub fn Vector4Distance(
+    v1: Vector4,
+    v2: Vector4,
+) f32 {
+    return raylib.mVector4Distance(
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v1))),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v2))),
+    );
+}
+
+///
+pub fn Vector4DistanceSqr(
+    v1: Vector4,
+    v2: Vector4,
+) f32 {
+    return raylib.mVector4DistanceSqr(
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v1))),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v2))),
+    );
+}
+
+///
+pub fn Vector4Scale(
+    v: Vector4,
+    scale: f32,
+) Vector4 {
+    var out: Vector4 = undefined;
+    raylib.mVector4Scale(
+        @as([*c]raylib.Vector4, @ptrCast(&out)),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v))),
+        scale,
+    );
+    return out;
+}
+
+///
+pub fn Vector4Multiply(
+    v1: Vector4,
+    v2: Vector4,
+) Vector4 {
+    var out: Vector4 = undefined;
+    raylib.mVector4Multiply(
+        @as([*c]raylib.Vector4, @ptrCast(&out)),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v1))),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v2))),
+    );
+    return out;
+}
+
+///
+pub fn Vector4Negate(
+    v: Vector4,
+) Vector4 {
+    var out: Vector4 = undefined;
+    raylib.mVector4Negate(
+        @as([*c]raylib.Vector4, @ptrCast(&out)),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v))),
+    );
+    return out;
+}
+
+///
+pub fn Vector4Divide(
+    v1: Vector4,
+    v2: Vector4,
+) Vector4 {
+    var out: Vector4 = undefined;
+    raylib.mVector4Divide(
+        @as([*c]raylib.Vector4, @ptrCast(&out)),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v1))),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v2))),
+    );
+    return out;
+}
+
+///
+pub fn Vector4Normalize(
+    v: Vector4,
+) Vector4 {
+    var out: Vector4 = undefined;
+    raylib.mVector4Normalize(
+        @as([*c]raylib.Vector4, @ptrCast(&out)),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v))),
+    );
+    return out;
+}
+
+///
+pub fn Vector4Min(
+    v1: Vector4,
+    v2: Vector4,
+) Vector4 {
+    var out: Vector4 = undefined;
+    raylib.mVector4Min(
+        @as([*c]raylib.Vector4, @ptrCast(&out)),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v1))),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v2))),
+    );
+    return out;
+}
+
+///
+pub fn Vector4Max(
+    v1: Vector4,
+    v2: Vector4,
+) Vector4 {
+    var out: Vector4 = undefined;
+    raylib.mVector4Max(
+        @as([*c]raylib.Vector4, @ptrCast(&out)),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v1))),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v2))),
+    );
+    return out;
+}
+
+///
+pub fn Vector4Lerp(
+    v1: Vector4,
+    v2: Vector4,
+    amount: f32,
+) Vector4 {
+    var out: Vector4 = undefined;
+    raylib.mVector4Lerp(
+        @as([*c]raylib.Vector4, @ptrCast(&out)),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v1))),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v2))),
+        amount,
+    );
+    return out;
+}
+
+///
+pub fn Vector4MoveTowards(
+    v: Vector4,
+    target: Vector4,
+    maxDistance: f32,
+) Vector4 {
+    var out: Vector4 = undefined;
+    raylib.mVector4MoveTowards(
+        @as([*c]raylib.Vector4, @ptrCast(&out)),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v))),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&target))),
+        maxDistance,
+    );
+    return out;
+}
+
+///
+pub fn Vector4Invert(
+    v: Vector4,
+) Vector4 {
+    var out: Vector4 = undefined;
+    raylib.mVector4Invert(
+        @as([*c]raylib.Vector4, @ptrCast(&out)),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&v))),
+    );
+    return out;
+}
+
+///
+pub fn Vector4Equals(
+    p: Vector4,
+    q: Vector4,
+) i32 {
+    return raylib.mVector4Equals(
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&p))),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&q))),
+    );
 }
 
 ///
@@ -10029,8 +10470,8 @@ pub fn MatrixFrustum(
     right: f64,
     bottom: f64,
     top: f64,
-    near: f64,
-    far: f64,
+    nearPlane: f64,
+    farPlane: f64,
 ) Matrix {
     var out: Matrix = undefined;
     raylib.mMatrixFrustum(
@@ -10039,8 +10480,8 @@ pub fn MatrixFrustum(
         right,
         bottom,
         top,
-        near,
-        far,
+        nearPlane,
+        farPlane,
     );
     return out;
 }
@@ -10297,6 +10738,26 @@ pub fn QuaternionSlerp(
         @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&q1))),
         @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&q2))),
         amount,
+    );
+    return out;
+}
+
+///
+pub fn QuaternionCubicHermiteSpline(
+    q1: Vector4,
+    outTangent1: Vector4,
+    q2: Vector4,
+    inTangent2: Vector4,
+    t: f32,
+) Vector4 {
+    var out: Vector4 = undefined;
+    raylib.mQuaternionCubicHermiteSpline(
+        @as([*c]raylib.Vector4, @ptrCast(&out)),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&q1))),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&outTangent1))),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&q2))),
+        @as([*c]raylib.Vector4, @ptrFromInt(@intFromPtr(&inTangent2))),
+        t,
     );
     return out;
 }
@@ -10819,6 +11280,12 @@ pub const rlRenderBatch = extern struct {
     currentDepth: f32,
 };
 
+/// Auxiliar matrix math functions
+pub const rl_float16 = extern struct {
+    ///
+    v: [16]f32,
+};
+
 /// NOTE: Helper types to be used instead of array return types for *ToFloat functions
 pub const float3 = extern struct {
     ///
@@ -11131,17 +11598,17 @@ pub const GamepadButton = enum(i32) {
     GAMEPAD_BUTTON_LEFT_FACE_LEFT = 4,
     /// Gamepad right button up (i.e. PS3: Triangle, Xbox: Y)
     GAMEPAD_BUTTON_RIGHT_FACE_UP = 5,
-    /// Gamepad right button right (i.e. PS3: Square, Xbox: X)
+    /// Gamepad right button right (i.e. PS3: Circle, Xbox: B)
     GAMEPAD_BUTTON_RIGHT_FACE_RIGHT = 6,
     /// Gamepad right button down (i.e. PS3: Cross, Xbox: A)
     GAMEPAD_BUTTON_RIGHT_FACE_DOWN = 7,
-    /// Gamepad right button left (i.e. PS3: Circle, Xbox: B)
+    /// Gamepad right button left (i.e. PS3: Square, Xbox: X)
     GAMEPAD_BUTTON_RIGHT_FACE_LEFT = 8,
     /// Gamepad top/back trigger left (first), it could be a trailing button
     GAMEPAD_BUTTON_LEFT_TRIGGER_1 = 9,
     /// Gamepad top/back trigger left (second), it could be a trailing button
     GAMEPAD_BUTTON_LEFT_TRIGGER_2 = 10,
-    /// Gamepad top/back trigger right (one), it could be a trailing button
+    /// Gamepad top/back trigger right (first), it could be a trailing button
     GAMEPAD_BUTTON_RIGHT_TRIGGER_1 = 11,
     /// Gamepad top/back trigger right (second), it could be a trailing button
     GAMEPAD_BUTTON_RIGHT_TRIGGER_2 = 12,
@@ -11443,15 +11910,15 @@ pub const Gesture = enum(i32) {
 
 /// Camera system modes
 pub const CameraMode = enum(i32) {
-    /// Custom camera
+    /// Camera custom, controlled by user (UpdateCamera() does nothing)
     CAMERA_CUSTOM = 0,
-    /// Free camera
+    /// Camera free mode
     CAMERA_FREE = 1,
-    /// Orbital camera
+    /// Camera orbital, around target, zoom supported
     CAMERA_ORBITAL = 2,
-    /// First person camera
+    /// Camera first person
     CAMERA_FIRST_PERSON = 3,
-    /// Third person camera
+    /// Camera third person
     CAMERA_THIRD_PERSON = 4,
 };
 
@@ -11760,7 +12227,7 @@ pub const RAYLIB_VERSION_PATCH: i32 = 0;
 pub const RAYLIB_VERSION: []const u8 = "5.1-dev";
 
 ///
-pub const PI: f32 = 3.14159265358979323846;
+pub const PI: f32 = 3.141592653589793e0;
 
 /// Light Gray
 pub const LIGHTGRAY: Color = .{ .r = 200, .g = 200, .b = 200, .a = 255 };
@@ -11841,7 +12308,7 @@ pub const MAGENTA: Color = .{ .r = 255, .g = 0, .b = 255, .a = 255 };
 pub const RAYWHITE: Color = .{ .r = 245, .g = 245, .b = 245, .a = 255 };
 
 ///
-pub const RLGL_VERSION: []const u8 = "4.5";
+pub const RLGL_VERSION: []const u8 = "5.0";
 
 ///
 pub const RL_DEFAULT_BATCH_BUFFER_ELEMENTS: i32 = 8192;
@@ -11862,10 +12329,10 @@ pub const RL_MAX_MATRIX_STACK_SIZE: i32 = 32;
 pub const RL_MAX_SHADER_LOCATIONS: i32 = 32;
 
 /// Default near cull distance
-pub const RL_CULL_DISTANCE_NEAR: f64 = 0.01;
+pub const RL_CULL_DISTANCE_NEAR: f64 = 1e-2;
 
 /// Default far cull distance
-pub const RL_CULL_DISTANCE_FAR: f64 = 1000.0;
+pub const RL_CULL_DISTANCE_FAR: f64 = 1e3;
 
 /// GL_TEXTURE_WRAP_S
 pub const RL_TEXTURE_WRAP_S: i32 = 10242;
@@ -12066,6 +12533,24 @@ pub const RL_READ_FRAMEBUFFER: i32 = 36008;
 pub const RL_DRAW_FRAMEBUFFER: i32 = 36009;
 
 ///
+pub const RL_DEFAULT_SHADER_ATTRIB_LOCATION_POSITION: i32 = 0;
+
+///
+pub const RL_DEFAULT_SHADER_ATTRIB_LOCATION_TEXCOORD: i32 = 1;
+
+///
+pub const RL_DEFAULT_SHADER_ATTRIB_LOCATION_NORMAL: i32 = 2;
+
+///
+pub const RL_DEFAULT_SHADER_ATTRIB_LOCATION_COLOR: i32 = 3;
+
+///
+pub const RL_DEFAULT_SHADER_ATTRIB_LOCATION_TANGENT: i32 = 4;
+
+///
+pub const RL_DEFAULT_SHADER_ATTRIB_LOCATION_TEXCOORD2: i32 = 5;
+
+///
 pub const GL_SHADING_LANGUAGE_VERSION: i32 = 35724;
 
 ///
@@ -12108,6 +12593,12 @@ pub const GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT: i32 = 34047;
 pub const GL_TEXTURE_MAX_ANISOTROPY_EXT: i32 = 34046;
 
 ///
+pub const GL_PROGRAM_POINT_SIZE: i32 = 34370;
+
+///
+pub const GL_LINE_WIDTH: i32 = 2849;
+
+///
 pub const GL_UNSIGNED_SHORT_5_6_5: i32 = 33635;
 
 ///
@@ -12122,22 +12613,22 @@ pub const GL_LUMINANCE: i32 = 6409;
 ///
 pub const GL_LUMINANCE_ALPHA: i32 = 6410;
 
-/// Bound by default to shader location: 0
+/// Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_NAME_POSITION
 pub const RL_DEFAULT_SHADER_ATTRIB_NAME_POSITION: []const u8 = "vertexPosition";
 
-/// Bound by default to shader location: 1
+/// Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_NAME_TEXCOORD
 pub const RL_DEFAULT_SHADER_ATTRIB_NAME_TEXCOORD: []const u8 = "vertexTexCoord";
 
-/// Bound by default to shader location: 2
+/// Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_NAME_NORMAL
 pub const RL_DEFAULT_SHADER_ATTRIB_NAME_NORMAL: []const u8 = "vertexNormal";
 
-/// Bound by default to shader location: 3
+/// Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_NAME_COLOR
 pub const RL_DEFAULT_SHADER_ATTRIB_NAME_COLOR: []const u8 = "vertexColor";
 
-/// Bound by default to shader location: 4
+/// Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_NAME_TANGENT
 pub const RL_DEFAULT_SHADER_ATTRIB_NAME_TANGENT: []const u8 = "vertexTangent";
 
-/// Bound by default to shader location: 5
+/// Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_NAME_TEXCOORD2
 pub const RL_DEFAULT_SHADER_ATTRIB_NAME_TEXCOORD2: []const u8 = "vertexTexCoord2";
 
 /// model-view-projection matrix
@@ -12168,4 +12659,4 @@ pub const RL_DEFAULT_SHADER_SAMPLER2D_NAME_TEXTURE1: []const u8 = "texture1";
 pub const RL_DEFAULT_SHADER_SAMPLER2D_NAME_TEXTURE2: []const u8 = "texture2";
 
 ///
-pub const EPSILON: f32 = 0.000001;
+pub const EPSILON: f32 = 1e-6;

--- a/raymath.json
+++ b/raymath.json
@@ -15,13 +15,13 @@
     {
       "name": "PI",
       "type": "FLOAT",
-      "value": "3.14159265358979323846",
+      "value": 3.14159265358979323846,
       "description": ""
     },
     {
       "name": "EPSILON",
       "type": "FLOAT",
-      "value": "0.000001",
+      "value": 0.000001,
       "description": ""
     },
     {
@@ -666,6 +666,36 @@
       ]
     },
     {
+      "name": "Vector2Min",
+      "description": "",
+      "returnType": "Vector2",
+      "params": [
+        {
+          "type": "Vector2",
+          "name": "v1"
+        },
+        {
+          "type": "Vector2",
+          "name": "v2"
+        }
+      ]
+    },
+    {
+      "name": "Vector2Max",
+      "description": "",
+      "returnType": "Vector2",
+      "params": [
+        {
+          "type": "Vector2",
+          "name": "v1"
+        },
+        {
+          "type": "Vector2",
+          "name": "v2"
+        }
+      ]
+    },
+    {
       "name": "Vector2Rotate",
       "description": "",
       "returnType": "Vector2",
@@ -760,6 +790,25 @@
         {
           "type": "Vector2",
           "name": "q"
+        }
+      ]
+    },
+    {
+      "name": "Vector2Refract",
+      "description": "",
+      "returnType": "Vector2",
+      "params": [
+        {
+          "type": "Vector2",
+          "name": "v"
+        },
+        {
+          "type": "Vector2",
+          "name": "n"
+        },
+        {
+          "type": "float",
+          "name": "r"
         }
       ]
     },
@@ -1103,6 +1152,25 @@
       ]
     },
     {
+      "name": "Vector3MoveTowards",
+      "description": "",
+      "returnType": "Vector3",
+      "params": [
+        {
+          "type": "Vector3",
+          "name": "v"
+        },
+        {
+          "type": "Vector3",
+          "name": "target"
+        },
+        {
+          "type": "float",
+          "name": "maxDistance"
+        }
+      ]
+    },
+    {
       "name": "Vector3Lerp",
       "description": "",
       "returnType": "Vector3",
@@ -1114,6 +1182,33 @@
         {
           "type": "Vector3",
           "name": "v2"
+        },
+        {
+          "type": "float",
+          "name": "amount"
+        }
+      ]
+    },
+    {
+      "name": "Vector3CubicHermite",
+      "description": "",
+      "returnType": "Vector3",
+      "params": [
+        {
+          "type": "Vector3",
+          "name": "v1"
+        },
+        {
+          "type": "Vector3",
+          "name": "tangent1"
+        },
+        {
+          "type": "Vector3",
+          "name": "v2"
+        },
+        {
+          "type": "Vector3",
+          "name": "tangent2"
         },
         {
           "type": "float",
@@ -1299,6 +1394,304 @@
         {
           "type": "float",
           "name": "r"
+        }
+      ]
+    },
+    {
+      "name": "Vector4Zero",
+      "description": "",
+      "returnType": "Vector4"
+    },
+    {
+      "name": "Vector4One",
+      "description": "",
+      "returnType": "Vector4"
+    },
+    {
+      "name": "Vector4Add",
+      "description": "",
+      "returnType": "Vector4",
+      "params": [
+        {
+          "type": "Vector4",
+          "name": "v1"
+        },
+        {
+          "type": "Vector4",
+          "name": "v2"
+        }
+      ]
+    },
+    {
+      "name": "Vector4AddValue",
+      "description": "",
+      "returnType": "Vector4",
+      "params": [
+        {
+          "type": "Vector4",
+          "name": "v"
+        },
+        {
+          "type": "float",
+          "name": "add"
+        }
+      ]
+    },
+    {
+      "name": "Vector4Subtract",
+      "description": "",
+      "returnType": "Vector4",
+      "params": [
+        {
+          "type": "Vector4",
+          "name": "v1"
+        },
+        {
+          "type": "Vector4",
+          "name": "v2"
+        }
+      ]
+    },
+    {
+      "name": "Vector4SubtractValue",
+      "description": "",
+      "returnType": "Vector4",
+      "params": [
+        {
+          "type": "Vector4",
+          "name": "v"
+        },
+        {
+          "type": "float",
+          "name": "add"
+        }
+      ]
+    },
+    {
+      "name": "Vector4Length",
+      "description": "",
+      "returnType": "float",
+      "params": [
+        {
+          "type": "Vector4",
+          "name": "v"
+        }
+      ]
+    },
+    {
+      "name": "Vector4LengthSqr",
+      "description": "",
+      "returnType": "float",
+      "params": [
+        {
+          "type": "Vector4",
+          "name": "v"
+        }
+      ]
+    },
+    {
+      "name": "Vector4DotProduct",
+      "description": "",
+      "returnType": "float",
+      "params": [
+        {
+          "type": "Vector4",
+          "name": "v1"
+        },
+        {
+          "type": "Vector4",
+          "name": "v2"
+        }
+      ]
+    },
+    {
+      "name": "Vector4Distance",
+      "description": "",
+      "returnType": "float",
+      "params": [
+        {
+          "type": "Vector4",
+          "name": "v1"
+        },
+        {
+          "type": "Vector4",
+          "name": "v2"
+        }
+      ]
+    },
+    {
+      "name": "Vector4DistanceSqr",
+      "description": "",
+      "returnType": "float",
+      "params": [
+        {
+          "type": "Vector4",
+          "name": "v1"
+        },
+        {
+          "type": "Vector4",
+          "name": "v2"
+        }
+      ]
+    },
+    {
+      "name": "Vector4Scale",
+      "description": "",
+      "returnType": "Vector4",
+      "params": [
+        {
+          "type": "Vector4",
+          "name": "v"
+        },
+        {
+          "type": "float",
+          "name": "scale"
+        }
+      ]
+    },
+    {
+      "name": "Vector4Multiply",
+      "description": "",
+      "returnType": "Vector4",
+      "params": [
+        {
+          "type": "Vector4",
+          "name": "v1"
+        },
+        {
+          "type": "Vector4",
+          "name": "v2"
+        }
+      ]
+    },
+    {
+      "name": "Vector4Negate",
+      "description": "",
+      "returnType": "Vector4",
+      "params": [
+        {
+          "type": "Vector4",
+          "name": "v"
+        }
+      ]
+    },
+    {
+      "name": "Vector4Divide",
+      "description": "",
+      "returnType": "Vector4",
+      "params": [
+        {
+          "type": "Vector4",
+          "name": "v1"
+        },
+        {
+          "type": "Vector4",
+          "name": "v2"
+        }
+      ]
+    },
+    {
+      "name": "Vector4Normalize",
+      "description": "",
+      "returnType": "Vector4",
+      "params": [
+        {
+          "type": "Vector4",
+          "name": "v"
+        }
+      ]
+    },
+    {
+      "name": "Vector4Min",
+      "description": "",
+      "returnType": "Vector4",
+      "params": [
+        {
+          "type": "Vector4",
+          "name": "v1"
+        },
+        {
+          "type": "Vector4",
+          "name": "v2"
+        }
+      ]
+    },
+    {
+      "name": "Vector4Max",
+      "description": "",
+      "returnType": "Vector4",
+      "params": [
+        {
+          "type": "Vector4",
+          "name": "v1"
+        },
+        {
+          "type": "Vector4",
+          "name": "v2"
+        }
+      ]
+    },
+    {
+      "name": "Vector4Lerp",
+      "description": "",
+      "returnType": "Vector4",
+      "params": [
+        {
+          "type": "Vector4",
+          "name": "v1"
+        },
+        {
+          "type": "Vector4",
+          "name": "v2"
+        },
+        {
+          "type": "float",
+          "name": "amount"
+        }
+      ]
+    },
+    {
+      "name": "Vector4MoveTowards",
+      "description": "",
+      "returnType": "Vector4",
+      "params": [
+        {
+          "type": "Vector4",
+          "name": "v"
+        },
+        {
+          "type": "Vector4",
+          "name": "target"
+        },
+        {
+          "type": "float",
+          "name": "maxDistance"
+        }
+      ]
+    },
+    {
+      "name": "Vector4Invert",
+      "description": "",
+      "returnType": "Vector4",
+      "params": [
+        {
+          "type": "Vector4",
+          "name": "v"
+        }
+      ]
+    },
+    {
+      "name": "Vector4Equals",
+      "description": "",
+      "returnType": "int",
+      "params": [
+        {
+          "type": "Vector4",
+          "name": "p"
+        },
+        {
+          "type": "Vector4",
+          "name": "q"
         }
       ]
     },
@@ -1527,11 +1920,11 @@
         },
         {
           "type": "double",
-          "name": "near"
+          "name": "nearPlane"
         },
         {
           "type": "double",
-          "name": "far"
+          "name": "farPlane"
         }
       ]
     },
@@ -1816,6 +2209,33 @@
         {
           "type": "float",
           "name": "amount"
+        }
+      ]
+    },
+    {
+      "name": "QuaternionCubicHermiteSpline",
+      "description": "",
+      "returnType": "Quaternion",
+      "params": [
+        {
+          "type": "Quaternion",
+          "name": "q1"
+        },
+        {
+          "type": "Quaternion",
+          "name": "outTangent1"
+        },
+        {
+          "type": "Quaternion",
+          "name": "q2"
+        },
+        {
+          "type": "Quaternion",
+          "name": "inTangent2"
+        },
+        {
+          "type": "float",
+          "name": "t"
         }
       ]
     },

--- a/rlgl.json
+++ b/rlgl.json
@@ -9,7 +9,7 @@
     {
       "name": "RLGL_VERSION",
       "type": "STRING",
-      "value": "4.5",
+      "value": "5.0",
       "description": ""
     },
     {
@@ -75,446 +75,482 @@
     {
       "name": "RL_DEFAULT_BATCH_BUFFER_ELEMENTS",
       "type": "INT",
-      "value": "8192",
+      "value": 8192,
       "description": ""
     },
     {
       "name": "RL_DEFAULT_BATCH_BUFFERS",
       "type": "INT",
-      "value": "1",
+      "value": 1,
       "description": "Default number of batch buffers (multi-buffering)"
     },
     {
       "name": "RL_DEFAULT_BATCH_DRAWCALLS",
       "type": "INT",
-      "value": "256",
+      "value": 256,
       "description": "Default number of batch draw calls (by state changes: mode, texture)"
     },
     {
       "name": "RL_DEFAULT_BATCH_MAX_TEXTURE_UNITS",
       "type": "INT",
-      "value": "4",
+      "value": 4,
       "description": "Maximum number of textures units that can be activated on batch drawing (SetShaderValueTexture())"
     },
     {
       "name": "RL_MAX_MATRIX_STACK_SIZE",
       "type": "INT",
-      "value": "32",
+      "value": 32,
       "description": "Maximum size of Matrix stack"
     },
     {
       "name": "RL_MAX_SHADER_LOCATIONS",
       "type": "INT",
-      "value": "32",
+      "value": 32,
       "description": "Maximum number of shader locations supported"
     },
     {
       "name": "RL_CULL_DISTANCE_NEAR",
       "type": "DOUBLE",
-      "value": "0.01",
+      "value": 0.01,
       "description": "Default near cull distance"
     },
     {
       "name": "RL_CULL_DISTANCE_FAR",
       "type": "DOUBLE",
-      "value": "1000.0",
+      "value": 1000.0,
       "description": "Default far cull distance"
     },
     {
       "name": "RL_TEXTURE_WRAP_S",
       "type": "INT",
-      "value": "10242",
+      "value": 10242,
       "description": "GL_TEXTURE_WRAP_S"
     },
     {
       "name": "RL_TEXTURE_WRAP_T",
       "type": "INT",
-      "value": "10243",
+      "value": 10243,
       "description": "GL_TEXTURE_WRAP_T"
     },
     {
       "name": "RL_TEXTURE_MAG_FILTER",
       "type": "INT",
-      "value": "10240",
+      "value": 10240,
       "description": "GL_TEXTURE_MAG_FILTER"
     },
     {
       "name": "RL_TEXTURE_MIN_FILTER",
       "type": "INT",
-      "value": "10241",
+      "value": 10241,
       "description": "GL_TEXTURE_MIN_FILTER"
     },
     {
       "name": "RL_TEXTURE_FILTER_NEAREST",
       "type": "INT",
-      "value": "9728",
+      "value": 9728,
       "description": "GL_NEAREST"
     },
     {
       "name": "RL_TEXTURE_FILTER_LINEAR",
       "type": "INT",
-      "value": "9729",
+      "value": 9729,
       "description": "GL_LINEAR"
     },
     {
       "name": "RL_TEXTURE_FILTER_MIP_NEAREST",
       "type": "INT",
-      "value": "9984",
+      "value": 9984,
       "description": "GL_NEAREST_MIPMAP_NEAREST"
     },
     {
       "name": "RL_TEXTURE_FILTER_NEAREST_MIP_LINEAR",
       "type": "INT",
-      "value": "9986",
+      "value": 9986,
       "description": "GL_NEAREST_MIPMAP_LINEAR"
     },
     {
       "name": "RL_TEXTURE_FILTER_LINEAR_MIP_NEAREST",
       "type": "INT",
-      "value": "9985",
+      "value": 9985,
       "description": "GL_LINEAR_MIPMAP_NEAREST"
     },
     {
       "name": "RL_TEXTURE_FILTER_MIP_LINEAR",
       "type": "INT",
-      "value": "9987",
+      "value": 9987,
       "description": "GL_LINEAR_MIPMAP_LINEAR"
     },
     {
       "name": "RL_TEXTURE_FILTER_ANISOTROPIC",
       "type": "INT",
-      "value": "12288",
+      "value": 12288,
       "description": "Anisotropic filter (custom identifier)"
     },
     {
       "name": "RL_TEXTURE_MIPMAP_BIAS_RATIO",
       "type": "INT",
-      "value": "16384",
+      "value": 16384,
       "description": "Texture mipmap bias, percentage ratio (custom identifier)"
     },
     {
       "name": "RL_TEXTURE_WRAP_REPEAT",
       "type": "INT",
-      "value": "10497",
+      "value": 10497,
       "description": "GL_REPEAT"
     },
     {
       "name": "RL_TEXTURE_WRAP_CLAMP",
       "type": "INT",
-      "value": "33071",
+      "value": 33071,
       "description": "GL_CLAMP_TO_EDGE"
     },
     {
       "name": "RL_TEXTURE_WRAP_MIRROR_REPEAT",
       "type": "INT",
-      "value": "33648",
+      "value": 33648,
       "description": "GL_MIRRORED_REPEAT"
     },
     {
       "name": "RL_TEXTURE_WRAP_MIRROR_CLAMP",
       "type": "INT",
-      "value": "34626",
+      "value": 34626,
       "description": "GL_MIRROR_CLAMP_EXT"
     },
     {
       "name": "RL_MODELVIEW",
       "type": "INT",
-      "value": "5888",
+      "value": 5888,
       "description": "GL_MODELVIEW"
     },
     {
       "name": "RL_PROJECTION",
       "type": "INT",
-      "value": "5889",
+      "value": 5889,
       "description": "GL_PROJECTION"
     },
     {
       "name": "RL_TEXTURE",
       "type": "INT",
-      "value": "5890",
+      "value": 5890,
       "description": "GL_TEXTURE"
     },
     {
       "name": "RL_LINES",
       "type": "INT",
-      "value": "1",
+      "value": 1,
       "description": "GL_LINES"
     },
     {
       "name": "RL_TRIANGLES",
       "type": "INT",
-      "value": "4",
+      "value": 4,
       "description": "GL_TRIANGLES"
     },
     {
       "name": "RL_QUADS",
       "type": "INT",
-      "value": "7",
+      "value": 7,
       "description": "GL_QUADS"
     },
     {
       "name": "RL_UNSIGNED_BYTE",
       "type": "INT",
-      "value": "5121",
+      "value": 5121,
       "description": "GL_UNSIGNED_BYTE"
     },
     {
       "name": "RL_FLOAT",
       "type": "INT",
-      "value": "5126",
+      "value": 5126,
       "description": "GL_FLOAT"
     },
     {
       "name": "RL_STREAM_DRAW",
       "type": "INT",
-      "value": "35040",
+      "value": 35040,
       "description": "GL_STREAM_DRAW"
     },
     {
       "name": "RL_STREAM_READ",
       "type": "INT",
-      "value": "35041",
+      "value": 35041,
       "description": "GL_STREAM_READ"
     },
     {
       "name": "RL_STREAM_COPY",
       "type": "INT",
-      "value": "35042",
+      "value": 35042,
       "description": "GL_STREAM_COPY"
     },
     {
       "name": "RL_STATIC_DRAW",
       "type": "INT",
-      "value": "35044",
+      "value": 35044,
       "description": "GL_STATIC_DRAW"
     },
     {
       "name": "RL_STATIC_READ",
       "type": "INT",
-      "value": "35045",
+      "value": 35045,
       "description": "GL_STATIC_READ"
     },
     {
       "name": "RL_STATIC_COPY",
       "type": "INT",
-      "value": "35046",
+      "value": 35046,
       "description": "GL_STATIC_COPY"
     },
     {
       "name": "RL_DYNAMIC_DRAW",
       "type": "INT",
-      "value": "35048",
+      "value": 35048,
       "description": "GL_DYNAMIC_DRAW"
     },
     {
       "name": "RL_DYNAMIC_READ",
       "type": "INT",
-      "value": "35049",
+      "value": 35049,
       "description": "GL_DYNAMIC_READ"
     },
     {
       "name": "RL_DYNAMIC_COPY",
       "type": "INT",
-      "value": "35050",
+      "value": 35050,
       "description": "GL_DYNAMIC_COPY"
     },
     {
       "name": "RL_FRAGMENT_SHADER",
       "type": "INT",
-      "value": "35632",
+      "value": 35632,
       "description": "GL_FRAGMENT_SHADER"
     },
     {
       "name": "RL_VERTEX_SHADER",
       "type": "INT",
-      "value": "35633",
+      "value": 35633,
       "description": "GL_VERTEX_SHADER"
     },
     {
       "name": "RL_COMPUTE_SHADER",
       "type": "INT",
-      "value": "37305",
+      "value": 37305,
       "description": "GL_COMPUTE_SHADER"
     },
     {
       "name": "RL_ZERO",
       "type": "INT",
-      "value": "0",
+      "value": 0,
       "description": "GL_ZERO"
     },
     {
       "name": "RL_ONE",
       "type": "INT",
-      "value": "1",
+      "value": 1,
       "description": "GL_ONE"
     },
     {
       "name": "RL_SRC_COLOR",
       "type": "INT",
-      "value": "768",
+      "value": 768,
       "description": "GL_SRC_COLOR"
     },
     {
       "name": "RL_ONE_MINUS_SRC_COLOR",
       "type": "INT",
-      "value": "769",
+      "value": 769,
       "description": "GL_ONE_MINUS_SRC_COLOR"
     },
     {
       "name": "RL_SRC_ALPHA",
       "type": "INT",
-      "value": "770",
+      "value": 770,
       "description": "GL_SRC_ALPHA"
     },
     {
       "name": "RL_ONE_MINUS_SRC_ALPHA",
       "type": "INT",
-      "value": "771",
+      "value": 771,
       "description": "GL_ONE_MINUS_SRC_ALPHA"
     },
     {
       "name": "RL_DST_ALPHA",
       "type": "INT",
-      "value": "772",
+      "value": 772,
       "description": "GL_DST_ALPHA"
     },
     {
       "name": "RL_ONE_MINUS_DST_ALPHA",
       "type": "INT",
-      "value": "773",
+      "value": 773,
       "description": "GL_ONE_MINUS_DST_ALPHA"
     },
     {
       "name": "RL_DST_COLOR",
       "type": "INT",
-      "value": "774",
+      "value": 774,
       "description": "GL_DST_COLOR"
     },
     {
       "name": "RL_ONE_MINUS_DST_COLOR",
       "type": "INT",
-      "value": "775",
+      "value": 775,
       "description": "GL_ONE_MINUS_DST_COLOR"
     },
     {
       "name": "RL_SRC_ALPHA_SATURATE",
       "type": "INT",
-      "value": "776",
+      "value": 776,
       "description": "GL_SRC_ALPHA_SATURATE"
     },
     {
       "name": "RL_CONSTANT_COLOR",
       "type": "INT",
-      "value": "32769",
+      "value": 32769,
       "description": "GL_CONSTANT_COLOR"
     },
     {
       "name": "RL_ONE_MINUS_CONSTANT_COLOR",
       "type": "INT",
-      "value": "32770",
+      "value": 32770,
       "description": "GL_ONE_MINUS_CONSTANT_COLOR"
     },
     {
       "name": "RL_CONSTANT_ALPHA",
       "type": "INT",
-      "value": "32771",
+      "value": 32771,
       "description": "GL_CONSTANT_ALPHA"
     },
     {
       "name": "RL_ONE_MINUS_CONSTANT_ALPHA",
       "type": "INT",
-      "value": "32772",
+      "value": 32772,
       "description": "GL_ONE_MINUS_CONSTANT_ALPHA"
     },
     {
       "name": "RL_FUNC_ADD",
       "type": "INT",
-      "value": "32774",
+      "value": 32774,
       "description": "GL_FUNC_ADD"
     },
     {
       "name": "RL_MIN",
       "type": "INT",
-      "value": "32775",
+      "value": 32775,
       "description": "GL_MIN"
     },
     {
       "name": "RL_MAX",
       "type": "INT",
-      "value": "32776",
+      "value": 32776,
       "description": "GL_MAX"
     },
     {
       "name": "RL_FUNC_SUBTRACT",
       "type": "INT",
-      "value": "32778",
+      "value": 32778,
       "description": "GL_FUNC_SUBTRACT"
     },
     {
       "name": "RL_FUNC_REVERSE_SUBTRACT",
       "type": "INT",
-      "value": "32779",
+      "value": 32779,
       "description": "GL_FUNC_REVERSE_SUBTRACT"
     },
     {
       "name": "RL_BLEND_EQUATION",
       "type": "INT",
-      "value": "32777",
+      "value": 32777,
       "description": "GL_BLEND_EQUATION"
     },
     {
       "name": "RL_BLEND_EQUATION_RGB",
       "type": "INT",
-      "value": "32777",
+      "value": 32777,
       "description": "GL_BLEND_EQUATION_RGB   // (Same as BLEND_EQUATION)"
     },
     {
       "name": "RL_BLEND_EQUATION_ALPHA",
       "type": "INT",
-      "value": "34877",
+      "value": 34877,
       "description": "GL_BLEND_EQUATION_ALPHA"
     },
     {
       "name": "RL_BLEND_DST_RGB",
       "type": "INT",
-      "value": "32968",
+      "value": 32968,
       "description": "GL_BLEND_DST_RGB"
     },
     {
       "name": "RL_BLEND_SRC_RGB",
       "type": "INT",
-      "value": "32969",
+      "value": 32969,
       "description": "GL_BLEND_SRC_RGB"
     },
     {
       "name": "RL_BLEND_DST_ALPHA",
       "type": "INT",
-      "value": "32970",
+      "value": 32970,
       "description": "GL_BLEND_DST_ALPHA"
     },
     {
       "name": "RL_BLEND_SRC_ALPHA",
       "type": "INT",
-      "value": "32971",
+      "value": 32971,
       "description": "GL_BLEND_SRC_ALPHA"
     },
     {
       "name": "RL_BLEND_COLOR",
       "type": "INT",
-      "value": "32773",
+      "value": 32773,
       "description": "GL_BLEND_COLOR"
     },
     {
       "name": "RL_READ_FRAMEBUFFER",
       "type": "INT",
-      "value": "36008",
+      "value": 36008,
       "description": "GL_READ_FRAMEBUFFER"
     },
     {
       "name": "RL_DRAW_FRAMEBUFFER",
       "type": "INT",
-      "value": "36009",
+      "value": 36009,
       "description": "GL_DRAW_FRAMEBUFFER"
+    },
+    {
+      "name": "RL_DEFAULT_SHADER_ATTRIB_LOCATION_POSITION",
+      "type": "INT",
+      "value": 0,
+      "description": ""
+    },
+    {
+      "name": "RL_DEFAULT_SHADER_ATTRIB_LOCATION_TEXCOORD",
+      "type": "INT",
+      "value": 1,
+      "description": ""
+    },
+    {
+      "name": "RL_DEFAULT_SHADER_ATTRIB_LOCATION_NORMAL",
+      "type": "INT",
+      "value": 2,
+      "description": ""
+    },
+    {
+      "name": "RL_DEFAULT_SHADER_ATTRIB_LOCATION_COLOR",
+      "type": "INT",
+      "value": 3,
+      "description": ""
+    },
+    {
+      "name": "RL_DEFAULT_SHADER_ATTRIB_LOCATION_TANGENT",
+      "type": "INT",
+      "value": 4,
+      "description": ""
+    },
+    {
+      "name": "RL_DEFAULT_SHADER_ATTRIB_LOCATION_TEXCOORD2",
+      "type": "INT",
+      "value": 5,
+      "description": ""
     },
     {
       "name": "RL_MATRIX_TYPE",
@@ -591,7 +627,7 @@
     {
       "name": "PI",
       "type": "FLOAT",
-      "value": "3.14159265358979323846",
+      "value": 3.14159265358979323846,
       "description": ""
     },
     {
@@ -609,115 +645,127 @@
     {
       "name": "GL_SHADING_LANGUAGE_VERSION",
       "type": "INT",
-      "value": "35724",
+      "value": 35724,
       "description": ""
     },
     {
       "name": "GL_COMPRESSED_RGB_S3TC_DXT1_EXT",
       "type": "INT",
-      "value": "33776",
+      "value": 33776,
       "description": ""
     },
     {
       "name": "GL_COMPRESSED_RGBA_S3TC_DXT1_EXT",
       "type": "INT",
-      "value": "33777",
+      "value": 33777,
       "description": ""
     },
     {
       "name": "GL_COMPRESSED_RGBA_S3TC_DXT3_EXT",
       "type": "INT",
-      "value": "33778",
+      "value": 33778,
       "description": ""
     },
     {
       "name": "GL_COMPRESSED_RGBA_S3TC_DXT5_EXT",
       "type": "INT",
-      "value": "33779",
+      "value": 33779,
       "description": ""
     },
     {
       "name": "GL_ETC1_RGB8_OES",
       "type": "INT",
-      "value": "36196",
+      "value": 36196,
       "description": ""
     },
     {
       "name": "GL_COMPRESSED_RGB8_ETC2",
       "type": "INT",
-      "value": "37492",
+      "value": 37492,
       "description": ""
     },
     {
       "name": "GL_COMPRESSED_RGBA8_ETC2_EAC",
       "type": "INT",
-      "value": "37496",
+      "value": 37496,
       "description": ""
     },
     {
       "name": "GL_COMPRESSED_RGB_PVRTC_4BPPV1_IMG",
       "type": "INT",
-      "value": "35840",
+      "value": 35840,
       "description": ""
     },
     {
       "name": "GL_COMPRESSED_RGBA_PVRTC_4BPPV1_IMG",
       "type": "INT",
-      "value": "35842",
+      "value": 35842,
       "description": ""
     },
     {
       "name": "GL_COMPRESSED_RGBA_ASTC_4x4_KHR",
       "type": "INT",
-      "value": "37808",
+      "value": 37808,
       "description": ""
     },
     {
       "name": "GL_COMPRESSED_RGBA_ASTC_8x8_KHR",
       "type": "INT",
-      "value": "37815",
+      "value": 37815,
       "description": ""
     },
     {
       "name": "GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT",
       "type": "INT",
-      "value": "34047",
+      "value": 34047,
       "description": ""
     },
     {
       "name": "GL_TEXTURE_MAX_ANISOTROPY_EXT",
       "type": "INT",
-      "value": "34046",
+      "value": 34046,
+      "description": ""
+    },
+    {
+      "name": "GL_PROGRAM_POINT_SIZE",
+      "type": "INT",
+      "value": 34370,
+      "description": ""
+    },
+    {
+      "name": "GL_LINE_WIDTH",
+      "type": "INT",
+      "value": 2849,
       "description": ""
     },
     {
       "name": "GL_UNSIGNED_SHORT_5_6_5",
       "type": "INT",
-      "value": "33635",
+      "value": 33635,
       "description": ""
     },
     {
       "name": "GL_UNSIGNED_SHORT_5_5_5_1",
       "type": "INT",
-      "value": "32820",
+      "value": 32820,
       "description": ""
     },
     {
       "name": "GL_UNSIGNED_SHORT_4_4_4_4",
       "type": "INT",
-      "value": "32819",
+      "value": 32819,
       "description": ""
     },
     {
       "name": "GL_LUMINANCE",
       "type": "INT",
-      "value": "6409",
+      "value": 6409,
       "description": ""
     },
     {
       "name": "GL_LUMINANCE_ALPHA",
       "type": "INT",
-      "value": "6410",
+      "value": 6410,
       "description": ""
     },
     {
@@ -742,37 +790,37 @@
       "name": "RL_DEFAULT_SHADER_ATTRIB_NAME_POSITION",
       "type": "STRING",
       "value": "vertexPosition",
-      "description": "Bound by default to shader location: 0"
+      "description": "Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_NAME_POSITION"
     },
     {
       "name": "RL_DEFAULT_SHADER_ATTRIB_NAME_TEXCOORD",
       "type": "STRING",
       "value": "vertexTexCoord",
-      "description": "Bound by default to shader location: 1"
+      "description": "Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_NAME_TEXCOORD"
     },
     {
       "name": "RL_DEFAULT_SHADER_ATTRIB_NAME_NORMAL",
       "type": "STRING",
       "value": "vertexNormal",
-      "description": "Bound by default to shader location: 2"
+      "description": "Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_NAME_NORMAL"
     },
     {
       "name": "RL_DEFAULT_SHADER_ATTRIB_NAME_COLOR",
       "type": "STRING",
       "value": "vertexColor",
-      "description": "Bound by default to shader location: 3"
+      "description": "Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_NAME_COLOR"
     },
     {
       "name": "RL_DEFAULT_SHADER_ATTRIB_NAME_TANGENT",
       "type": "STRING",
       "value": "vertexTangent",
-      "description": "Bound by default to shader location: 4"
+      "description": "Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_NAME_TANGENT"
     },
     {
       "name": "RL_DEFAULT_SHADER_ATTRIB_NAME_TEXCOORD2",
       "type": "STRING",
       "value": "vertexTexCoord2",
-      "description": "Bound by default to shader location: 5"
+      "description": "Bound by default to shader location: RL_DEFAULT_SHADER_ATTRIB_NAME_TEXCOORD2"
     },
     {
       "name": "RL_DEFAULT_SHADER_UNIFORM_NAME_MVP",
@@ -827,6 +875,12 @@
       "type": "STRING",
       "value": "texture2",
       "description": "texture2 (texture slot active 2)"
+    },
+    {
+      "name": "rlMatrixToFloat(mat)",
+      "type": "MACRO",
+      "value": "(rlMatrixToFloatV(mat).v)",
+      "description": "Get float vector for Matrix"
     },
     {
       "name": "MIN(a,b)",
@@ -948,9 +1002,19 @@
           "description": "Vertex texture coordinates (UV - 2 components per vertex) (shader-location = 1)"
         },
         {
+          "type": "float *",
+          "name": "normals",
+          "description": "Vertex normal (XYZ - 3 components per vertex) (shader-location = 2)"
+        },
+        {
           "type": "unsigned char *",
           "name": "colors",
           "description": "Vertex colors (RGBA - 4 components per vertex) (shader-location = 3)"
+        },
+        {
+          "type": "#if defined(GRAPHICS_API_OPENGL_11) || defined(GRAPHICS_API_OPENunsigned int *",
+          "name": "indices",
+          "description": "Vertex indices (in case vertex data comes indexed) (6 indices per quad)"
         },
         {
           "type": "unsigned int *",
@@ -958,14 +1022,34 @@
           "description": "Vertex indices (in case vertex data comes indexed) (6 indices per quad)"
         },
         {
+          "type": "#endif",
+          "name": "indices",
+          "description": "Vertex indices (in case vertex data comes indexed) (6 indices per quad)"
+        },
+        {
+          "type": "#if defined(GRAPHICS_API_OPENGL_ES2)",
+          "name": "indices",
+          "description": "Vertex indices (in case vertex data comes indexed) (6 indices per quad)"
+        },
+        {
+          "type": "unsigned short *",
+          "name": "indices",
+          "description": "Vertex indices (in case vertex data comes indexed) (6 indices per quad)"
+        },
+        {
+          "type": "#endif",
+          "name": "vaoId",
+          "description": "OpenGL Vertex Array Object id"
+        },
+        {
           "type": "unsigned int",
           "name": "vaoId",
           "description": "OpenGL Vertex Array Object id"
         },
         {
-          "type": "unsigned int[4]",
+          "type": "unsigned int[5]",
           "name": "vboId",
-          "description": "OpenGL Vertex Buffer Objects id (4 types of vertex data)"
+          "description": "OpenGL Vertex Buffer Objects id (5 types of vertex data)"
         }
       ]
     },
@@ -1254,6 +1338,17 @@
           "type": "int",
           "name": "framebufferHeight",
           "description": "Current framebuffer height"
+        }
+      ]
+    },
+    {
+      "name": "rl_float16",
+      "description": "Auxiliar matrix math functions",
+      "fields": [
+        {
+          "type": "float[16]",
+          "name": "v",
+          "description": ""
         }
       ]
     }
@@ -2081,6 +2176,31 @@
       ]
     },
     {
+      "name": "rlSetClipPlanes",
+      "description": "Set clip planes distances",
+      "returnType": "void",
+      "params": [
+        {
+          "type": "double",
+          "name": "nearPlane"
+        },
+        {
+          "type": "double",
+          "name": "farPlane"
+        }
+      ]
+    },
+    {
+      "name": "rlGetCullDistanceNear",
+      "description": "Get cull plane distance near",
+      "returnType": "double"
+    },
+    {
+      "name": "rlGetCullDistanceFar",
+      "description": "Get cull plane distance far",
+      "returnType": "double"
+    },
+    {
       "name": "rlBegin",
       "description": "Initialize drawing mode (how to organize vertex)",
       "returnType": "void",
@@ -2454,6 +2574,11 @@
       "returnType": "void"
     },
     {
+      "name": "rlGetActiveFramebuffer",
+      "description": "Get the currently active render texture (fbo), 0 for default framebuffer",
+      "returnType": "unsigned int"
+    },
+    {
       "name": "rlActiveDrawBuffers",
       "description": "Activate multiple draw color buffers",
       "returnType": "void",
@@ -2509,7 +2634,7 @@
     },
     {
       "name": "rlBindFramebuffer",
-      "description": "Bind framebuffer (FBO) ",
+      "description": "Bind framebuffer (FBO)",
       "returnType": "void",
       "params": [
         {
@@ -3074,8 +3199,8 @@
           "name": "stride"
         },
         {
-          "type": "const void *",
-          "name": "pointer"
+          "type": "int",
+          "name": "offset"
         }
       ]
     },
@@ -3406,17 +3531,7 @@
     {
       "name": "rlLoadFramebuffer",
       "description": "Load an empty framebuffer",
-      "returnType": "unsigned int",
-      "params": [
-        {
-          "type": "int",
-          "name": "width"
-        },
-        {
-          "type": "int",
-          "name": "height"
-        }
-      ]
+      "returnType": "unsigned int"
     },
     {
       "name": "rlFramebufferAttach",
@@ -3901,28 +4016,6 @@
       "name": "rlLoadDrawQuad",
       "description": "Load and draw a quad",
       "returnType": "void"
-    },
-    {
-      "name": "rlGetMatrixProjectionStereo",
-      "description": "",
-      "returnType": "Matrix",
-      "params": [
-        {
-          "type": "int",
-          "name": "eye"
-        }
-      ]
-    },
-    {
-      "name": "rlGetMatrixViewOffsetStereo",
-      "description": "",
-      "returnType": "Matrix",
-      "params": [
-        {
-          "type": "int",
-          "name": "eye"
-        }
-      ]
     }
   ]
 }

--- a/type_mapping.zig
+++ b/type_mapping.zig
@@ -85,7 +85,7 @@ pub const Intermediate = struct {
                     continue :outer;
                 }
             }
-            const define = parseRaylibDefine(allocator, d) orelse continue :outer;
+            const define = try parseRaylibDefine(allocator, d) orelse continue :outer;
 
             if (i < defines.items.len) {
                 try defines.insert(i, define);
@@ -248,31 +248,38 @@ pub const Define = struct {
     custom: bool = false,
 };
 
-pub fn parseRaylibDefine(allocator: Allocator, s: RaylibDefine) ?Define {
+pub fn parseRaylibDefine(allocator: Allocator, s: RaylibDefine) !?Define {
     var typ: []const u8 = undefined;
     var value: []const u8 = undefined;
+    const strValue = try jsonStringify(allocator, s.value);
+    defer allocator.free(strValue);
 
     if (eql("INT", s.type)) {
         typ = "i32";
-        value = std.fmt.allocPrint(allocator, "{s}", .{s.value}) catch return null;
+        std.debug.print("i32: {s}", .{strValue});
+        value = std.fmt.allocPrint(allocator, "{s}", .{strValue}) catch return null;
     } else if (eql("LONG", s.type)) {
         typ = "i64";
-        value = std.fmt.allocPrint(allocator, "{s}", .{s.value}) catch return null;
+        std.debug.print("i64: {s}", .{strValue});
+        value = std.fmt.allocPrint(allocator, "{s}", .{strValue}) catch return null;
     } else if (eql("FLOAT", s.type)) {
         typ = "f32";
-        value = std.fmt.allocPrint(allocator, "{s}", .{s.value}) catch return null;
+        std.debug.print("f32: {s}", .{strValue});
+        value = std.fmt.allocPrint(allocator, "{s}", .{strValue}) catch return null;
     } else if (eql("DOUBLE", s.type)) {
         typ = "f64";
-        value = std.fmt.allocPrint(allocator, "{s}", .{s.value}) catch return null;
+        std.debug.print("f64: {s}", .{strValue});
+        value = std.fmt.allocPrint(allocator, "{s}", .{strValue}) catch return null;
     } else if (eql("STRING", s.type)) {
         typ = "[]const u8";
-        value = std.fmt.allocPrint(allocator, "\"{s}\"", .{s.value}) catch return null;
+        std.debug.print("[]const u8: {s}", .{strValue});
+        value = std.fmt.allocPrint(allocator, "\"{s}\"", .{strValue}) catch return null;
     } else if (eql("COLOR", s.type)) {
         typ = "Color";
-        std.debug.assert(startsWith(s.value, "CLITERAL(Color){"));
-        std.debug.assert(endsWith(s.value, "}"));
+        std.debug.assert(startsWith(strValue, "CLITERAL(Color){"));
+        std.debug.assert(endsWith(strValue, "}"));
 
-        const componentString = s.value["CLITERAL(Color){".len .. s.value.len - 1];
+        const componentString = strValue["CLITERAL(Color){".len .. strValue.len - 1];
         var spliterator = std.mem.split(u8, componentString, ",");
         var r = spliterator.next() orelse return null;
         r = std.mem.trim(u8, r, " \t\r\n");
@@ -454,7 +461,7 @@ test "toZig" {
     try expectEqualStrings("?[*]Vector2", try toZig(a, "Vector2 *"));
 }
 
-const raylibToZigType = std.ComptimeStringMap([]const u8, .{
+const raylibToZigType = std.StaticStringMap([]const u8).initComptime(.{
     .{ "void", "void" },
     .{ "bool", "bool" },
     .{ "char", "u8" },
@@ -470,7 +477,7 @@ const raylibToZigType = std.ComptimeStringMap([]const u8, .{
     .{ "double", "f64" },
 });
 
-const fixedMapping = std.ComptimeStringMap([]const u8, .{
+const fixedMapping = std.StaticStringMap([]const u8).initComptime(.{
     .{ "void *", "*anyopaque" },
     .{ "const void *", "*const anyopaque" },
     .{ "const unsigned char *", "[*:0]const u8" },
@@ -484,7 +491,7 @@ const fixedMapping = std.ComptimeStringMap([]const u8, .{
 
 //--- Raylib parser JSONs -------------------------------------------------------------------------
 
-const alias = std.ComptimeStringMap([]const u8, .{
+const alias = std.StaticStringMap([]const u8).initComptime(.{
     .{ "Camera", "Camera3D" },
     .{ "Texture", "Texture2D" },
     .{ "TextureCubemap", "Texture2D" },
@@ -494,7 +501,7 @@ const alias = std.ComptimeStringMap([]const u8, .{
     .{ "PhysicsBody", "*PhysicsBodyData" },
 });
 
-const cAlias = std.ComptimeStringMap([]const u8, .{
+const cAlias = std.StaticStringMap([]const u8).initComptime(.{
     .{ "Camera", "Camera3D" },
     .{ "Texture", "Texture2D" },
     .{ "TextureCubemap", "Texture2D" },
@@ -651,7 +658,7 @@ pub const RaylibFunctionParam = struct {
 pub const RaylibDefine = struct {
     name: []const u8,
     type: []const u8,
-    value: []const u8,
+    value: std.json.Value,
     description: ?[]const u8 = null,
 };
 
@@ -660,7 +667,7 @@ pub const RaylibDefine = struct {
 /// true if C type is primitive or a pointer to anything
 /// this means we don't need to wrap it in a pointer
 pub fn isPrimitiveOrPointer(c: []const u8) bool {
-    const primitiveTypes = std.ComptimeStringMap(void, .{
+    const primitiveTypes = std.StaticStringMap(void).initComptime(.{
         .{ "void", {} },
         .{ "bool", {} },
         .{ "char", {} },
@@ -688,4 +695,9 @@ fn startsWith(haystack: []const u8, needle: []const u8) bool {
 
 fn endsWith(haystack: []const u8, needle: []const u8) bool {
     return std.mem.endsWith(u8, haystack, needle);
+}
+
+fn jsonStringify(allocator: Allocator, value: std.json.Value) ![]const u8 {
+    const jsonString = try json.stringifyAlloc(allocator, value, .{});
+    return std.mem.trim(u8, jsonString, "\"");
 }


### PR DESCRIPTION
Continued on #41

Changes:

- update raylib
- add `.zig-cache` to `.gititnore`
- add `build.zig.zon` to readme, this is now needed with the latest raylib
- use `LazyPath`'s
- `ComptimeStringMap` to `StaticStringMap`

These changes do mean that this is not backwards compatible with zig 0.12